### PR TITLE
Fix multiple clicks on debug button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [1.20.1] 2022-06-21
+
+- Fix multiple clicks on the Apex debugger button that caused multiple debug sessions to be started
+
 ## [1.20.0] 2022-06-12
 
 - New command **Merge package.xml files**

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-sfdx-hardis",
   "displayName": "SFDX Hardis",
   "description": "Handle Salesforce DX and Git without knowing Salesforce DX or Git !",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "icon": "resources/hardis-logo.png",
   "publisher": "NicolasVuillamy",
   "license": "AGPL-3.0",

--- a/src/hardis-debugger.ts
+++ b/src/hardis-debugger.ts
@@ -95,13 +95,15 @@ export class HardisDebugger {
   private async launchDebugger() {
     await this.runSfdxExtensionCommand("sfdx.force.apex.log.get");
     let launched = false;
+    // Wait for user to select a log
     const listener = vscode.window.onDidChangeActiveTextEditor((textEditor) => {
       if (textEditor && textEditor?.document?.uri?.fsPath.endsWith(".log")) {
         launched = true;
         this.debugLogFile(textEditor.document.uri);
-        listener.dispose();
       }
+      listener.dispose();
     });
+    // Launch debugger from active log file opened in text editor
     setTimeout(() => {
       if (
         launched === false &&


### PR DESCRIPTION
Don't open multiple debugging sessions if the debug button is clicked then the log selection window is dismissed later reopened