### PR TITLE
Feat: adds commands for generating Project and Flows documentation in PDF + allow generation of multiple Flows' documentations at once

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -488,7 +488,7 @@ export class Commands {
           );
           return;
         }
-        const command = `sf hardis:doc:flows-to-pdf --inputfile "${relativePath}"`;
+        const command = `sf hardis:doc:flow2markdown --pdf --inputfile "${relativePath}"`;
         vscode.commands.executeCommand(
           "vscode-sfdx-hardis.execute-command",
           command,

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -52,7 +52,7 @@ export class Commands {
     this.registerSimulateDeployment();
     this.registerGeneratePackageXmlDoc();
     this.registerGenerateFlowDocumentation();
-    this.registerGenerateFullFlowDocumentation();
+    this.registerGeneratePdfFlowDocumentation();
     this.registerGenerateFlowVisualGitDiff();
   }
 
@@ -476,10 +476,10 @@ export class Commands {
     this.disposables.push(disposable);
   }
 
-  registerGenerateFullFlowDocumentation() {
+  registerGeneratePdfFlowDocumentation() {
     // Open external command
     const disposable = vscode.commands.registerCommand(
-      "vscode-sfdx-hardis.generateFullFlowDocumentation",
+      "vscode-sfdx-hardis.generatePdfFlowDocumentation",
       async (uri: vscode.Uri) => {
         const relativePath = vscode.workspace.asRelativePath(uri);
         if (!relativePath.endsWith(".flow-meta.xml")) {
@@ -488,7 +488,7 @@ export class Commands {
           );
           return;
         }
-        const command = `sf hardis:doc:flow-full-docs --inputfile "${relativePath}"`;
+        const command = `sf hardis:doc:flows-to-pdf --inputfile "${relativePath}"`;
         vscode.commands.executeCommand(
           "vscode-sfdx-hardis.execute-command",
           command,

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -52,6 +52,7 @@ export class Commands {
     this.registerSimulateDeployment();
     this.registerGeneratePackageXmlDoc();
     this.registerGenerateFlowDocumentation();
+    this.registerGenerateFullFlowDocumentation();
     this.registerGenerateFlowVisualGitDiff();
   }
 
@@ -466,6 +467,28 @@ export class Commands {
           return;
         }
         const command = `sf hardis:doc:flow2markdown --inputfile "${relativePath}"`;
+        vscode.commands.executeCommand(
+          "vscode-sfdx-hardis.execute-command",
+          command,
+        );
+      },
+    );
+    this.disposables.push(disposable);
+  }
+
+  registerGenerateFullFlowDocumentation() {
+    // Open external command
+    const disposable = vscode.commands.registerCommand(
+      "vscode-sfdx-hardis.generateFullFlowDocumentation",
+      async (uri: vscode.Uri) => {
+        const relativePath = vscode.workspace.asRelativePath(uri);
+        if (!relativePath.endsWith(".flow-meta.xml")) {
+          vscode.window.showWarningMessage(
+            "This command only works with Flow files :)",
+          );
+          return;
+        }
+        const command = `sf hardis:doc:flow-full-docs --inputfile "${relativePath}"`;
         vscode.commands.executeCommand(
           "vscode-sfdx-hardis.execute-command",
           command,

--- a/src/hardis-commands-provider.ts
+++ b/src/hardis-commands-provider.ts
@@ -814,6 +814,15 @@ export class HardisCommandsProvider
               "https://sfdx-hardis.cloudity.com/hardis/doc/flow2markdown/",
           },
           {
+            id: "hardis:doc:flow-full-docs",
+            label: "Full Flow Documentation",
+            command: "sf hardis:doc:fullflowdocs",
+            tooltip: "Generates Visual Documentation for multiple Flows in Markdown and PDF",
+            requiresProject: true,
+            helpUrl:
+              "https://sfdx-hardis.cloudity.com/hardis/doc/", /** TODO: add help URL */
+          },
+          {
             id: "hardis:project:generate:flow-git-diff",
             label: "Single Flow Visual Git Diff",
             command: "sf hardis:project:generate:flow-git-diff",

--- a/src/hardis-commands-provider.ts
+++ b/src/hardis-commands-provider.ts
@@ -814,10 +814,10 @@ export class HardisCommandsProvider
               "https://sfdx-hardis.cloudity.com/hardis/doc/flow2markdown/",
           },
           {
-            id: "hardis:doc:flow-full-docs",
-            label: "Full Flow Documentation",
-            command: "sf hardis:doc:fullflowdocs",
-            tooltip: "Generates Visual Documentation for multiple Flows in Markdown and PDF",
+            id: "hardis:doc:flows-to-pdf",
+            label: "PDF Flows Documentation",
+            command: "sf hardis:doc:flows-to-pdf",
+            tooltip: "Generates Visual Documentation for multiple Flows in PDF and Markdown",
             requiresProject: true,
             helpUrl:
               "https://sfdx-hardis.cloudity.com/hardis/doc/", /** TODO: add help URL */

--- a/src/hardis-commands-provider.ts
+++ b/src/hardis-commands-provider.ts
@@ -774,6 +774,16 @@ export class HardisCommandsProvider
               "https://sfdx-hardis.cloudity.com/hardis/doc/project2markdown/",
           },
           {
+            id: "hardis:doc:project2markdown-pdf",
+            label: "Project Documentation (with PDF)",
+            command: "sf hardis:doc:project2markdown --pdf",
+            tooltip:
+              "Generates markdown and PDF pages with SF Project content: List of metadatas, installed packages...",
+            requiresProject: true,
+            helpUrl:
+              "https://sfdx-hardis.cloudity.com/hardis/doc/project2markdown/",
+          },
+          {
             id: "hardis:doc:project2markdown-history",
             label: "Project Documentation (with history)",
             command: "sf hardis:doc:project2markdown --with-history",
@@ -806,21 +816,21 @@ export class HardisCommandsProvider
           },
           {
             id: "hardis:doc:flow2markdown",
-            label: "Single Flow Documentation",
+            label: "Multiple Flows Documentation",
             command: "sf hardis:doc:flow2markdown",
-            tooltip: "Generates Visual Documentation for a Flow",
+            tooltip: "Generates Visual Documentation for selected Flows",
             requiresProject: true,
             helpUrl:
               "https://sfdx-hardis.cloudity.com/hardis/doc/flow2markdown/",
           },
           {
-            id: "hardis:doc:flows-to-pdf",
-            label: "PDF Flows Documentation",
-            command: "sf hardis:doc:flows-to-pdf",
-            tooltip: "Generates Visual Documentation for multiple Flows in PDF and Markdown",
+            id: "hardis:doc:flow2markdown-pdf",
+            label: "Multiple Flows Documentation (with PDF)",
+            command: "sf hardis:doc:flow2markdown --pdf",
+            tooltip: "Generates Markdown and PDF Documentation for selected Flows ",
             requiresProject: true,
             helpUrl:
-              "https://sfdx-hardis.cloudity.com/hardis/doc/", /** TODO: add help URL */
+              "https://sfdx-hardis.cloudity.com/hardis/doc/flow2markdown/",
           },
           {
             id: "hardis:project:generate:flow-git-diff",

--- a/src/themeUtils.ts
+++ b/src/themeUtils.ts
@@ -245,6 +245,7 @@ export class ThemeUtils {
         hardis: "old.svg",
       },
       "hardis:doc:project2markdown": { vscode: "book", hardis: "doc.svg" },
+      "hardis:doc:project2markdown-pdf": { vscode: "book", hardis: "doc.svg" },
       "hardis:doc:project2markdown-history": {
         vscode: "book",
         hardis: "doc.svg",
@@ -254,7 +255,7 @@ export class ThemeUtils {
         hardis: "push.svg",
       },
       "hardis:doc:flow2markdown": { vscode: "git-branch", hardis: "doc.svg" },
-      "hardis:doc:flows-to-pdf": { vscode: "git-branch", hardis: "doc.svg" },
+      "hardis:doc:flow2markdown-pdf": { vscode: "git-branch", hardis: "doc.svg" },
       "hardis:doc:flow2markdown-history": {
         vscode: "git-branch",
         hardis: "doc.svg",

--- a/src/themeUtils.ts
+++ b/src/themeUtils.ts
@@ -254,7 +254,7 @@ export class ThemeUtils {
         hardis: "push.svg",
       },
       "hardis:doc:flow2markdown": { vscode: "git-branch", hardis: "doc.svg" },
-      "hardis:doc:flow-full-docs": { vscode: "git-branch", hardis: "doc.svg" },
+      "hardis:doc:flows-to-pdf": { vscode: "git-branch", hardis: "doc.svg" },
       "hardis:doc:flow2markdown-history": {
         vscode: "git-branch",
         hardis: "doc.svg",

--- a/src/themeUtils.ts
+++ b/src/themeUtils.ts
@@ -254,6 +254,7 @@ export class ThemeUtils {
         hardis: "push.svg",
       },
       "hardis:doc:flow2markdown": { vscode: "git-branch", hardis: "doc.svg" },
+      "hardis:doc:flow-full-docs": { vscode: "git-branch", hardis: "doc.svg" },
       "hardis:doc:flow2markdown-history": {
         vscode: "git-branch",
         hardis: "doc.svg",


### PR DESCRIPTION
Hey! I'm implementing the commands from here [sfdx-hardis #1079 ](https://github.com/hardisgroupcom/sfdx-hardis/pull/1079) in the VS code extension :)
 
This PR adds the following commands:
1. **Multiple Flows Documentation (with PDF**): generate documentation, in Markdown and PDF, for selected flows;
2. **Project Documentation (with PDF):** generate the project documentation in Markdown and, for Apex Classes, Pages, Objects and Flows, also in PDF.
 
It also changes the old command **"Single Flow Documentation"** for the new **"Multiple Flows Documentation"** that allows generating docs for more than one flow at once.