### PR TITLE
Enhances color customization and fixes theme issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,15 @@
 
 ## [Unreleased]
 
+## [5.9.0] 2024-06-21
+
 - Do not display error message if sf is installed via CodeBuilder
 - Debugger: perform SF related actions only if the breakpoint detected is on an Apex Class
 - Improve performances when running debugger
 - Add a test CI/CD workflow
 - Add a copilot instructions file
 - Replace deprecated vscode-test with @vscode/test-electron
+- Fix issue that messed with user VsCode theme / colors customizations
 
 ## [5.9.0] 2024-06-18
 

--- a/package.json
+++ b/package.json
@@ -417,6 +417,7 @@
     "glob": "^11.0.0",
     "lru-cache": "^7.18.3",
     "mocha": "^10.0.0",
+    "rimraf": "^6.0.1",
     "typescript": "^5.0.0"
   },
   "dependencies": {

--- a/src/hardis-colors.ts
+++ b/src/hardis-colors.ts
@@ -126,7 +126,7 @@ export class HardisColors {
     try {
       const color = await vscode.window.showInputBox(inputBoxOptions);
       return color;
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (e) {
       return null;
     }
@@ -156,10 +156,10 @@ export class HardisColors {
 
   describeOrgColors() {
     return {
-      "production": "#8c1004", // red
-      "major": "#a66004", // orange
-      "dev": "#2f53a8", // blue
-    }
+      production: "#8c1004", // red
+      major: "#a66004", // orange
+      dev: "#2f53a8", // blue
+    };
   }
 
   // Get org color :)
@@ -214,11 +214,12 @@ export class HardisColors {
   async applyColor(color: string | null) {
     if (vscode.workspace.workspaceFolders) {
       const config = vscode.workspace.getConfiguration();
-      let colorCustomization = config.get(
-        "workbench.colorCustomizations",
-      );
+      let colorCustomization = config.get("workbench.colorCustomizations");
       // Ensure colorCustomization is an object
-      if (typeof colorCustomization !== "object" || colorCustomization === null) {
+      if (
+        typeof colorCustomization !== "object" ||
+        colorCustomization === null
+      ) {
         colorCustomization = {};
       }
       const colorCustomObj = colorCustomization as Record<string, any>;
@@ -237,13 +238,21 @@ export class HardisColors {
         colorCustomObj["activityBar.background"]
       ) {
         // Restore colors if found, or delete them
-        if (colorCustomObj["statusBar.background"] && colorCustomObj["statusBar.backgroundPrevious"]) {
-          colorCustomObj["statusBar.background"] = colorCustomObj["statusBar.backgroundPrevious"];
+        if (
+          colorCustomObj["statusBar.background"] &&
+          colorCustomObj["statusBar.backgroundPrevious"]
+        ) {
+          colorCustomObj["statusBar.background"] =
+            colorCustomObj["statusBar.backgroundPrevious"];
         } else {
           delete colorCustomObj["statusBar.background"];
         }
-        if (colorCustomObj["activityBar.background"] && colorCustomObj["activityBar.backgroundPrevious"]) {
-          colorCustomObj["activityBar.background"] = colorCustomObj["activityBar.backgroundPrevious"];
+        if (
+          colorCustomObj["activityBar.background"] &&
+          colorCustomObj["activityBar.backgroundPrevious"]
+        ) {
+          colorCustomObj["activityBar.background"] =
+            colorCustomObj["activityBar.backgroundPrevious"];
         } else {
           delete colorCustomObj["activityBar.background"];
         }
@@ -308,14 +317,22 @@ export class HardisColors {
 
   savePreviousCustomizedColors(colorCustomObj: Record<string, any>) {
     if (
-      colorCustomObj["statusBar.background"] && !Object.values(this.describeOrgColors()).includes(colorCustomObj["statusBar.background"])
+      colorCustomObj["statusBar.background"] &&
+      !Object.values(this.describeOrgColors()).includes(
+        colorCustomObj["statusBar.background"],
+      )
     ) {
-      colorCustomObj["statusBar.backgroundPrevious"] = colorCustomObj["statusBar.background"];
+      colorCustomObj["statusBar.backgroundPrevious"] =
+        colorCustomObj["statusBar.background"];
     }
     if (
-      colorCustomObj["activityBar.background"] && !Object.values(this.describeOrgColors()).includes(colorCustomObj["activityBar.background"])
+      colorCustomObj["activityBar.background"] &&
+      !Object.values(this.describeOrgColors()).includes(
+        colorCustomObj["activityBar.background"],
+      )
     ) {
-      colorCustomObj["activityBar.backgroundPrevious"] = colorCustomObj["activityBar.background"];
+      colorCustomObj["activityBar.backgroundPrevious"] =
+        colorCustomObj["activityBar.background"];
     }
   }
 

--- a/src/hardis-colors.ts
+++ b/src/hardis-colors.ts
@@ -126,6 +126,7 @@ export class HardisColors {
     try {
       const color = await vscode.window.showInputBox(inputBoxOptions);
       return color;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (e) {
       return null;
     }
@@ -150,6 +151,14 @@ export class HardisColors {
           true,
         );
       }
+    }
+  }
+
+  describeOrgColors() {
+    return {
+      "production": "#8c1004", // red
+      "major": "#a66004", // orange
+      "dev": "#2f53a8", // blue
     }
   }
 
@@ -183,7 +192,7 @@ export class HardisColors {
             `🦙 Your default org is a MAJOR org linked to git branch ${this.majorOrgBranch}, be careful because the CI/CD Server is supposed to deploy there, not you :)`,
             "Close",
           );
-          return forcedColor || "#a66004"; // orange !
+          return forcedColor || this.describeOrgColors()["major"]; // orange !
         }
         return forcedColor || null; // green !
       } else if (PRODUCTION_EDITIONS.includes(org.OrganizationType)) {
@@ -192,10 +201,10 @@ export class HardisColors {
           "🦙 Your default org is a PRODUCTION org, be careful what you do :)",
           "Close",
         );
-        return forcedColor || "#8c1004"; // red !
+        return forcedColor || this.describeOrgColors()["production"]; // red !
       }
       // Dev org, trial org...
-      return forcedColor || "#2f53a8"; // blue
+      return forcedColor || this.describeOrgColors()["dev"]; // blue
     }
     // Default color
     return forcedColor || null;
@@ -205,32 +214,45 @@ export class HardisColors {
   async applyColor(color: string | null) {
     if (vscode.workspace.workspaceFolders) {
       const config = vscode.workspace.getConfiguration();
-      const colorCustomization: any = config.get(
+      let colorCustomization = config.get(
         "workbench.colorCustomizations",
       );
+      // Ensure colorCustomization is an object
+      if (typeof colorCustomization !== "object" || colorCustomization === null) {
+        colorCustomization = {};
+      }
+      const colorCustomObj = colorCustomization as Record<string, any>;
+      this.savePreviouscustomizedColors(colorCustomObj);
       if (color !== null) {
-        colorCustomization["statusBar.background"] = color;
-        colorCustomization["activityBar.background"] = color;
+        colorCustomObj["statusBar.background"] = color;
+        colorCustomObj["activityBar.background"] = color;
         // Do not update config file with blank color if there wasn't a previous config
         await config.update(
           "workbench.colorCustomizations",
-          colorCustomization,
+          colorCustomObj,
           vscode.ConfigurationTarget.Workspace,
         );
       } else if (
-        colorCustomization["statusBar.background"] ||
-        colorCustomization["activityBar.background"]
+        colorCustomObj["statusBar.background"] ||
+        colorCustomObj["activityBar.background"]
       ) {
-        // Remove colors
-        colorCustomization["statusBar.background"] = null;
-        colorCustomization["activityBar.background"] = null;
-        if (Object.keys(colorCustomization).length > 0) {
-          await config.update(
-            "workbench.colorCustomizations",
-            {},
-            vscode.ConfigurationTarget.Workspace,
-          );
+        // Restore colors if found, or delete them
+        if (colorCustomObj["statusBar.background"] && colorCustomObj["statusBar.backgroundPrevious"]) {
+          colorCustomObj["statusBar.background"] = colorCustomObj["statusBar.backgroundPrevious"];
+        } else {
+          delete colorCustomObj["statusBar.background"];
         }
+        if (colorCustomObj["activityBar.background"] && colorCustomObj["activityBar.backgroundPrevious"]) {
+          colorCustomObj["activityBar.background"] = colorCustomObj["activityBar.backgroundPrevious"];
+        } else {
+          delete colorCustomObj["activityBar.background"];
+        }
+        // Remove colors
+        await config.update(
+          "workbench.colorCustomizations",
+          colorCustomObj,
+          vscode.ConfigurationTarget.Workspace,
+        );
       }
     }
   }
@@ -284,12 +306,28 @@ export class HardisColors {
     return [];
   }
 
+  savePreviouscustomizedColors(colorCustomObj: Record<string, any>) {
+    if (
+      colorCustomObj["statusBar.background"] && !Object.values(this.describeOrgColors()).includes(colorCustomObj["statusBar.background"])
+    ) {
+      colorCustomObj["statusBar.backgroundPrevious"] = colorCustomObj["statusBar.background"];
+    }
+    if (
+      colorCustomObj["activityBar.background"] && !Object.values(this.describeOrgColors()).includes(colorCustomObj["activityBar.background"])
+    ) {
+      colorCustomObj["activityBar.backgroundPrevious"] = colorCustomObj["activityBar.background"];
+    }
+  }
+
   reset() {
     this.currentDefaultOrg = undefined;
     this.currentDefaultOrgDomain = undefined;
     this.majorOrgInstanceUrls = [];
     this.disposables.map((disposable) => disposable.dispose());
-    this.applyColor(null);
+    const config = vscode.workspace.getConfiguration("vsCodeSfdxHardis");
+    if (!config.get("disableVsCodeColors") === true) {
+      this.applyColor(null);
+    }
   }
 
   // Remove custom colors when quitting the extension or VsCode

--- a/src/hardis-colors.ts
+++ b/src/hardis-colors.ts
@@ -222,7 +222,7 @@ export class HardisColors {
         colorCustomization = {};
       }
       const colorCustomObj = colorCustomization as Record<string, any>;
-      this.savePreviouscustomizedColors(colorCustomObj);
+      this.savePreviousCustomizedColors(colorCustomObj);
       if (color !== null) {
         colorCustomObj["statusBar.background"] = color;
         colorCustomObj["activityBar.background"] = color;
@@ -306,7 +306,7 @@ export class HardisColors {
     return [];
   }
 
-  savePreviouscustomizedColors(colorCustomObj: Record<string, any>) {
+  savePreviousCustomizedColors(colorCustomObj: Record<string, any>) {
     if (
       colorCustomObj["statusBar.background"] && !Object.values(this.describeOrgColors()).includes(colorCustomObj["statusBar.background"])
     ) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3350,6 +3350,14 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.1.0.tgz#0fe13b9522e1473f51b558ee796e08f11f9b489f"
   integrity sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==
 
+rimraf@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-6.0.1.tgz#ffb8ad8844dd60332ab15f52bc104bc3ed71ea4e"
+  integrity sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==
+  dependencies:
+    glob "^11.0.0"
+    package-json-from-dist "^1.0.0"
+
 run-applescript@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/run-applescript/-/run-applescript-7.0.0.tgz#e5a553c2bffd620e169d276c1cd8f1b64778fbeb"


### PR DESCRIPTION
Improves the color customization feature and prevents it from overriding user's VS Code theme settings.

- Persists user's original color settings before applying custom colors.
- Restores original colors when the extension is disabled or uninstalled.
- Introduces predefined color descriptions for different org types.

Fixes https://github.com/hardisgroupcom/vscode-sfdx-hardis/issues/198