### PR TITLE
Updated styles: lightning datatable, IDE dark theme and pipeline font colour [needs to be tested]

### DIFF
--- a/src/webviews/lwc-ui/modules/s/commandExecution/commandExecution.css
+++ b/src/webviews/lwc-ui/modules/s/commandExecution/commandExecution.css
@@ -190,90 +190,6 @@
   background: #a8a8a8;
 }
 
-/* Dark theme support */
-@media (prefers-color-scheme: dark) {
-  .log-container {
-    background-color: #1a1a1a;
-    border-color: #3a3a3a;
-    color: #e5e5e5;
-  }
-
-  .log-section {
-    background-color: #2a2a2a;
-    border-color: #4a4a4a;
-  }
-
-  .section-header:hover {
-    background-color: #3a3a3a;
-  }
-
-  .section-logs {
-    border-top-color: #4a4a4a;
-  }
-
-  .section-logs > div[data-log-type="error"],
-  .log-lines > div[data-log-type="error"] {
-    background-color: #2d1b1b;
-    color: #ff6b6b;
-  }
-
-  .section-logs > div[data-log-type="warning"],
-  .log-lines > div[data-log-type="warning"] {
-    background-color: #2d2419;
-    color: #ffa726;
-  }
-
-  .section-logs > div[data-log-type="success"],
-  .log-lines > div[data-log-type="success"] {
-    background-color: #1b2d1b;
-    color: #66bb6a;
-  }
-
-  .section-logs > div[data-log-type="action"],
-  .log-lines > div[data-log-type="action"] {
-    background-color: #1b2636;
-    color: #42a5f5;
-  }
-
-  .section-logs > div[data-log-type="log"],
-  .log-lines > div[data-log-type="log"] {
-    background-color: #222222;
-    color: #bdbdbd;
-  }
-
-  .section-logs > div[data-log-type="query"],
-  .log-lines > div[data-log-type="query"] {
-    background-color: #1b2a3a;
-    color: #69c0ff;
-  }
-
-  /* Dark theme sub-command styling */
-  .section-logs > div[data-is-subcommand="true"][data-is-running="true"],
-  .log-lines > div[data-is-subcommand="true"][data-is-running="true"] {
-    background-color: #3d2f1f;
-    border-left-color: #ff8c00;
-    box-shadow: 0 2px 4px rgba(255, 140, 0, 0.3);
-  }
-
-  .section-logs > div[data-is-subcommand="true"][data-is-running="false"],
-  .log-lines > div[data-is-subcommand="true"][data-is-running="false"] {
-    background-color: #1e2a3a;
-    border-left-color: #0ea5e9;
-  }
-
-  .log-container::-webkit-scrollbar-track {
-    background: #2a2a2a;
-  }
-
-  .log-container::-webkit-scrollbar-thumb {
-    background: #4a4a4a;
-  }
-
-  .log-container::-webkit-scrollbar-thumb:hover {
-    background: #5a5a5a;
-  }
-}
-
 /* Answer formatting styles */
 .answer-formatted {
   background-color: #f8f9fa;
@@ -308,12 +224,4 @@
 
 .download-panel .slds-button-group {
   gap: 0.25rem;
-}
-
-/* Dark theme support for download panel */
-@media (prefers-color-scheme: dark) {
-  .download-panel {
-    background-color: #2a2a2a;
-    border-top-color: #4a4a4a;
-  }
 }

--- a/src/webviews/lwc-ui/modules/s/commandExecution/commandExecution.html
+++ b/src/webviews/lwc-ui/modules/s/commandExecution/commandExecution.html
@@ -133,13 +133,12 @@
                         <template if:true={logLine.isTable}>
                           <div key={logLine.id} style="padding-top: 0; padding-bottom: 0.5rem;">
                             <template lwc:if={section.tableLog}>
-                              <div class="slds-table_header-fixed_container slds-scrollable_x" style="max-width: 100%;">
+                              <div class="slds-scrollable_x" style="max-width: 100%; color: black;">
                                 <lightning-datatable
                                   key-field="id"
                                   data={section.tableRows}
                                   columns={section.tableLog.columns}
                                   hide-checkbox-column
-                                  class="slds-table slds-table_bordered slds-table_cell-buffer slds-table_striped"
                                 >
                                 </lightning-datatable>
                               </div>

--- a/src/webviews/lwc-ui/modules/s/pipeline/pipeline.css
+++ b/src/webviews/lwc-ui/modules/s/pipeline/pipeline.css
@@ -1,3 +1,7 @@
+:host {
+    color: #000000;
+}
+
 .pipeline-container {
     /* Add your CSS for pipeline visualization here */
     border: 1px solid #ccc;


### PR DESCRIPTION
Updated table styles: 
<img width="1214" height="320" alt="image" src="https://github.com/user-attachments/assets/b1e07171-6587-452b-a92f-5f9027cb38bc" />

Updated font colour for DevOps Pipeline.

Removed styles for dark IDE theme.