### PR TITLE
Adds Orgs Manager feature

### DIFF
--- a/.github/linters/.cspell.json
+++ b/.github/linters/.cspell.json
@@ -207,6 +207,8 @@
     "nvuillam",
     "oclif",
     "oncellchange",
+    "onrowaction",
+    "onrowselection",
     "onsave",
     "orgmissingitems",
     "orgs",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Show combobox filter to simplify selection when there are many values
+- New feature: Orgs Manager to list, manage and clean all orgs known by Salesforce CLI
 
 ## [6.2.2] 2024-08-29
 

--- a/package.json
+++ b/package.json
@@ -275,6 +275,11 @@
         "icon": "$(package)"
       },
       {
+        "command": "vscode-sfdx-hardis.openOrgsManager",
+        "title": "SFDX Hardis: Open Orgs Manager",
+        "icon": "$(organization)"
+      },
+      {
         "command": "vscode-sfdx-hardis.runLocalHtmlDocPages",
         "title": "SFDX Hardis: Run Local HTML Doc Pages",
         "icon": "$(globe)"

--- a/package.json
+++ b/package.json
@@ -373,6 +373,11 @@
           "group": "navigation"
         },
         {
+          "command": "vscode-sfdx-hardis.openOrgsManager",
+          "when": "view == sfdx-hardis-status",
+          "group": "navigation"
+        },
+        {
           "command": "vscode-sfdx-hardis.selectColorForOrg",
           "when": "view == sfdx-hardis-status",
           "group": "navigation"

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -79,7 +79,10 @@ export class Commands {
         const lwcManager = LwcPanelManager.getInstance();
         // Load orgs using orgUtils
         try {
-          const orgs = await this.loadOrgsWithProgress(false, "Loading Salesforce orgs...\n(it can be long, make some cleaning to make it faster 🙃)");
+          const orgs = await this.loadOrgsWithProgress(
+            false,
+            "Loading Salesforce orgs...\n(it can be long, make some cleaning to make it faster 🙃)",
+          );
 
           const panel = lwcManager.getOrCreatePanel("s-org-manager", {
             orgs: orgs,
@@ -95,22 +98,25 @@ export class Commands {
               currentAllFlag = allFlag;
               const newOrgs = await this.loadOrgsWithProgress(allFlag);
               panel.sendInitializationData({ orgs: newOrgs });
-            } 
-            else if (type === "connectOrg") {
+            } else if (type === "connectOrg") {
               // run hardis:org:select
               const username = data.username;
-              const command = `sf hardis:org:select --username "${username || ''}"`;
+              const command = `sf hardis:org:select --username "${username || ""}"`;
               this.commandRunner.executeCommand(command);
-            }
-            else if (type === "forgetOrgs") {
+            } else if (type === "forgetOrgs") {
               try {
                 const usernames = data?.usernames || [];
                 if (usernames.length === 0) {
-                  vscode.window.showInformationMessage("No orgs selected to forget.");
+                  vscode.window.showInformationMessage(
+                    "No orgs selected to forget.",
+                  );
                   return;
                 }
 
-                const result = await this.forgetOrgsWithProgress(usernames, `Forgetting ${usernames.length} org(s)...`);
+                const result = await this.forgetOrgsWithProgress(
+                  usernames,
+                  `Forgetting ${usernames.length} org(s)...`,
+                );
 
                 // send back result and refresh list
                 const newOrgs = await this.loadOrgsWithProgress(currentAllFlag);
@@ -123,21 +129,24 @@ export class Commands {
                   `Error forgetting orgs: ${error?.message || error}`,
                 );
               }
-            } 
-            else if (type === "removeRecommended") {
-                // If LWC sent usernames, use them; otherwise fallback to detection
-                let usernames: string[] = [];
-                if (data && Array.isArray(data.usernames) && data.usernames.length > 0) {
-                  usernames = data.usernames.filter(Boolean);
-                }
+            } else if (type === "removeRecommended") {
+              // If LWC sent usernames, use them; otherwise fallback to detection
+              let usernames: string[] = [];
+              if (
+                data &&
+                Array.isArray(data.usernames) &&
+                data.usernames.length > 0
+              ) {
+                usernames = data.usernames.filter(Boolean);
+              }
 
-                if (usernames.length === 0) {
-                  vscode.window.showInformationMessage(
-                    "No recommended orgs found to remove.",
-                  );
-                  return;
-                }
-              
+              if (usernames.length === 0) {
+                vscode.window.showInformationMessage(
+                  "No recommended orgs found to remove.",
+                );
+                return;
+              }
+
               try {
                 const confirm = await vscode.window.showWarningMessage(
                   `This will forget ${usernames.length} orgs (disconnected, deleted or expired). Are you sure?`,
@@ -149,7 +158,10 @@ export class Commands {
                   return;
                 }
 
-                const result = await this.forgetOrgsWithProgress(usernames, `Forgetting ${usernames.length} recommended org(s)...`);
+                const result = await this.forgetOrgsWithProgress(
+                  usernames,
+                  `Forgetting ${usernames.length} recommended org(s)...`,
+                );
                 vscode.window.showInformationMessage(
                   `Forgot ${result.successUsernames.length} recommended org(s).`,
                 );
@@ -199,7 +211,10 @@ export class Commands {
           }
           const u = usernames[i];
           const increment = Math.round(100 / total);
-          progress.report({ message: `Forgetting ${u} (${i + 1}/${total})`, increment });
+          progress.report({
+            message: `Forgetting ${u} (${i + 1}/${total})`,
+            increment,
+          });
           try {
             await execSfdxJson(`sf org logout --target-org ${u} --noprompt`);
             successUsernames.push(u);
@@ -216,7 +231,9 @@ export class Commands {
 
   // Helper: load orgs with a progress notification; preserves return value from listAllOrgs(all)
   private async loadOrgsWithProgress(all: boolean = false, title?: string) {
-    const t = title || (all ? "Loading all Salesforce orgs..." : "Loading Salesforce orgs...");
+    const t =
+      title ||
+      (all ? "Loading all Salesforce orgs..." : "Loading Salesforce orgs...");
     return await vscode.window.withProgress(
       {
         location: vscode.ProgressLocation.Notification,

--- a/src/hardis-commands-provider.ts
+++ b/src/hardis-commands-provider.ts
@@ -490,8 +490,9 @@ export class HardisCommandsProvider
           {
             id: "orgs-manager",
             label: "Orgs Manager",
-            tooltip: "Open Orgs Manager to connect to new orgs, disconnect from existing orgs and make some cleaning",
-            command: "vscode-sfdx-hardis.openOrgsManager"
+            tooltip:
+              "Open Orgs Manager to connect to new orgs, disconnect from existing orgs and make some cleaning",
+            command: "vscode-sfdx-hardis.openOrgsManager",
           },
           {
             id: "org:user:freeze",

--- a/src/hardis-commands-provider.ts
+++ b/src/hardis-commands-provider.ts
@@ -488,6 +488,12 @@ export class HardisCommandsProvider
         label: "Org Operations",
         commands: [
           {
+            id: "orgs-manager",
+            label: "Orgs Manager",
+            tooltip: "Open Orgs Manager to connect to new orgs, disconnect from existing orgs and make some cleaning",
+            command: "vscode-sfdx-hardis.openOrgsManager"
+          },
+          {
             id: "org:user:freeze",
             label: "Freeze users",
             tooltip:

--- a/src/hardis-websocket-server.ts
+++ b/src/hardis-websocket-server.ts
@@ -249,6 +249,14 @@ export class LocalWebSocketServer {
     // Request to refresh status box
     else if (data.event === "refreshStatus") {
       vscode.commands.executeCommand("vscode-sfdx-hardis.refreshStatusView");
+      // Refresh Orgs Manager panel if existing
+      const panelManager = LwcPanelManager.getInstance();
+      const orgManagerPanel = panelManager.getPanel("s-org-manager");
+      if (orgManagerPanel) {
+        orgManagerPanel.sendMessage({
+          type: "refreshOrgs",
+        });
+     }
     }
     // Request to refresh commands box
     else if (data.event === "refreshCommands") {

--- a/src/hardis-websocket-server.ts
+++ b/src/hardis-websocket-server.ts
@@ -256,7 +256,7 @@ export class LocalWebSocketServer {
         orgManagerPanel.sendMessage({
           type: "refreshOrgs",
         });
-     }
+      }
     }
     // Request to refresh commands box
     else if (data.event === "refreshCommands") {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -228,6 +228,7 @@ export async function execCommand(
       commandResult =
         COMMANDS_RESULTS[command].result ??
         (await COMMANDS_RESULTS[command].promise);
+      delete COMMANDS_RESULTS[command];
     } else {
       // no cache
       Logger.log("[vscode-sfdx-hardis][command] " + command);
@@ -236,6 +237,11 @@ export async function execCommand(
       COMMANDS_RESULTS[command] = { promise: commandResultPromise };
       commandResult = await commandResultPromise;
       COMMANDS_RESULTS[command] = { result: commandResult };
+      setTimeout(() => {
+        if (COMMANDS_RESULTS[command] && COMMANDS_RESULTS[command].result) {
+          delete COMMANDS_RESULTS[command];
+        }
+      }, 1000 * 20); // keep result in memory for 20 seconds
       console.timeEnd(command);
     }
   } catch (e: any) {

--- a/src/utils/orgUtils.ts
+++ b/src/utils/orgUtils.ts
@@ -1,0 +1,33 @@
+import { execSfdxJson } from "../utils";
+
+export async function listOrgs() {
+    // List all orgs
+    const orgList = await execSfdxJson("sf org list --all");
+    // For each org, add the org type (Production, Sandbox, Developer, Scratch), without calling SF Cli again
+    for (const org of orgList) {
+        if (org.isScratch) {
+            org.orgType = "Scratch";
+        } else if (org.instanceUrl.includes(".sandbox")) {
+            org.orgType = "Sandbox";
+        } else {
+            org.orgType = "Production";
+        }
+    }
+    return orgList;
+}
+
+export async function forgetOrgs(orgUsernames: string[]) {
+    const results = await Promise.allSettled(
+        orgUsernames.map((username) => execSfdxJson(`sf org logout --target-org ${username} --noprompt`))
+    );
+    const successUsernames: string[] = [];
+    const errorUsernames: string[] = [];
+    results.forEach((result, index) => {
+        if (result.status === "fulfilled") {
+            successUsernames.push(orgUsernames[index]);
+        } else {
+            errorUsernames.push(orgUsernames[index]);
+        }
+    });
+    return { successUsernames, errorUsernames };
+}

--- a/src/utils/orgUtils.ts
+++ b/src/utils/orgUtils.ts
@@ -1,104 +1,113 @@
 import { execSfdxJson } from "../utils";
 
 export type SalesforceOrg = {
-    username?: string;
-    alias?: string;
-    orgType?: 'production' | 'sandbox' | 'scratch' | 'other' ;
-    isDefault?: boolean;
-    isScratch?: boolean;
-    isSandbox?: boolean;
-    instanceUrl?: string;
-    loginUrl?: string;
-    orgId?: string;
-    createdDate?: string;
-    expirationDate?: string | null;
-    connectedStatus?: string;
-    name?: string;
+  username?: string;
+  alias?: string;
+  orgType?: "production" | "sandbox" | "scratch" | "other";
+  isDefault?: boolean;
+  isScratch?: boolean;
+  isSandbox?: boolean;
+  instanceUrl?: string;
+  loginUrl?: string;
+  orgId?: string;
+  createdDate?: string;
+  expirationDate?: string | null;
+  connectedStatus?: string;
+  name?: string;
 };
 
-export async function listAllOrgs(all=false): Promise<SalesforceOrg[]> {
-    // List all orgs
-    const orgListRes = await execSfdxJson(`sf org list${all ? ' --all' : ''}`);
+export async function listAllOrgs(all = false): Promise<SalesforceOrg[]> {
+  // List all orgs
+  const orgListRes = await execSfdxJson(`sf org list${all ? " --all" : ""}`);
 
-    // orgListRes.result may contain several arrays grouped by type (other, sandboxes, nonScratchOrgs, devHubs, scratchOrgs, ...)
-    // We want to return a single flattened list of orgs. Deduplicate by orgId when present, otherwise by username.
-    const result = orgListRes?.result || {};
+  // orgListRes.result may contain several arrays grouped by type (other, sandboxes, nonScratchOrgs, devHubs, scratchOrgs, ...)
+  // We want to return a single flattened list of orgs. Deduplicate by orgId when present, otherwise by username.
+  const result = orgListRes?.result || {};
 
-    // Collect candidate arrays from the result object. If result is an array (older formats), use it directly.
-    const buckets: any[] = [];
-    if (Array.isArray(result)) {
-        buckets.push(...result);
-    } else if (typeof result === "object" && result !== null) {
-        for (const val of Object.values(result)) {
-            if (Array.isArray(val)) {
-                buckets.push(...val);
-            }
-        }
+  // Collect candidate arrays from the result object. If result is an array (older formats), use it directly.
+  const buckets: any[] = [];
+  if (Array.isArray(result)) {
+    buckets.push(...result);
+  } else if (typeof result === "object" && result !== null) {
+    for (const val of Object.values(result)) {
+      if (Array.isArray(val)) {
+        buckets.push(...val);
+      }
     }
-    const seen = new Map<string, SalesforceOrg>();
-    for (const org of buckets) {
-        if (!org) {
-            continue;
-        }
-        const key = org.orgId || org.username || org.instanceUrl || JSON.stringify(org);
-        if (seen.has(key)) {
-            // already added (avoid duplicates)
-            continue;
-        }
-        // Determine org type
-        let orgType: 'production' | 'sandbox' | 'scratch' | 'other' = "other";
-        if (org.isScratch) {
-            orgType = "scratch";
-        } else if (org.isSandbox || (org.instanceUrl && org.instanceUrl.includes(".sandbox"))) {
-            orgType = "sandbox";
-        }
-        else if (!org.instanceUrl.includes("dev-ed") && !org.instanceUrl.includes("test") && !org.instanceUrl.includes("sandbox")) {
-            orgType = "production";
-        }
-        const normalized: SalesforceOrg = {
-            username: org.username,
-            alias: org.alias,
-            orgType: orgType,
-            isDefault: org.isDefault,
-            isScratch: !!org.isScratch,
-            isSandbox: !!org.isSandbox,
-            instanceUrl: org.instanceUrl,
-            loginUrl: org.loginUrl,
-            orgId: org.orgId,
-            createdDate: org.createdDate,
-            expirationDate: org.expirationDate || org.trailExpirationDate,
-            connectedStatus: org.connectedStatus,
-            name: org.name,
-        };
-        seen.set(key, normalized);
+  }
+  const seen = new Map<string, SalesforceOrg>();
+  for (const org of buckets) {
+    if (!org) {
+      continue;
     }
+    const key =
+      org.orgId || org.username || org.instanceUrl || JSON.stringify(org);
+    if (seen.has(key)) {
+      // already added (avoid duplicates)
+      continue;
+    }
+    // Determine org type
+    let orgType: "production" | "sandbox" | "scratch" | "other" = "other";
+    if (org.isScratch) {
+      orgType = "scratch";
+    } else if (
+      org.isSandbox ||
+      (org.instanceUrl && org.instanceUrl.includes(".sandbox"))
+    ) {
+      orgType = "sandbox";
+    } else if (
+      !org.instanceUrl.includes("dev-ed") &&
+      !org.instanceUrl.includes("test") &&
+      !org.instanceUrl.includes("sandbox")
+    ) {
+      orgType = "production";
+    }
+    const normalized: SalesforceOrg = {
+      username: org.username,
+      alias: org.alias,
+      orgType: orgType,
+      isDefault: org.isDefault,
+      isScratch: !!org.isScratch,
+      isSandbox: !!org.isSandbox,
+      instanceUrl: org.instanceUrl,
+      loginUrl: org.loginUrl,
+      orgId: org.orgId,
+      createdDate: org.createdDate,
+      expirationDate: org.expirationDate || org.trailExpirationDate,
+      connectedStatus: org.connectedStatus,
+      name: org.name,
+    };
+    seen.set(key, normalized);
+  }
 
-    // Sort by orgType (production, sandbox, other, scratch), then by instanceUrl
-    const orgTypeOrder = { production: 0, sandbox: 1, other: 2, scratch: 3 };
-    return Array.from(seen.values()).sort((a, b) => {
-        const aType = orgTypeOrder[a.orgType || "other"];
-        const bType = orgTypeOrder[b.orgType || "other"];
-        if (aType !== bType) {
-            return aType - bType;
-        }
-        const aUrl = a.instanceUrl || "";
-        const bUrl = b.instanceUrl || "";
-        return aUrl.localeCompare(bUrl);
-    });
+  // Sort by orgType (production, sandbox, other, scratch), then by instanceUrl
+  const orgTypeOrder = { production: 0, sandbox: 1, other: 2, scratch: 3 };
+  return Array.from(seen.values()).sort((a, b) => {
+    const aType = orgTypeOrder[a.orgType || "other"];
+    const bType = orgTypeOrder[b.orgType || "other"];
+    if (aType !== bType) {
+      return aType - bType;
+    }
+    const aUrl = a.instanceUrl || "";
+    const bUrl = b.instanceUrl || "";
+    return aUrl.localeCompare(bUrl);
+  });
 }
 
 export async function forgetOrgs(orgUsernames: string[]) {
-    const results = await Promise.allSettled(
-        orgUsernames.map((username) => execSfdxJson(`sf org logout --target-org ${username} --noprompt`))
-    );
-    const successUsernames: string[] = [];
-    const errorUsernames: string[] = [];
-    results.forEach((result, index) => {
-        if (result.status === "fulfilled") {
-            successUsernames.push(orgUsernames[index]);
-        } else {
-            errorUsernames.push(orgUsernames[index]);
-        }
-    });
-    return { successUsernames, errorUsernames };
+  const results = await Promise.allSettled(
+    orgUsernames.map((username) =>
+      execSfdxJson(`sf org logout --target-org ${username} --noprompt`),
+    ),
+  );
+  const successUsernames: string[] = [];
+  const errorUsernames: string[] = [];
+  results.forEach((result, index) => {
+    if (result.status === "fulfilled") {
+      successUsernames.push(orgUsernames[index]);
+    } else {
+      errorUsernames.push(orgUsernames[index]);
+    }
+  });
+  return { successUsernames, errorUsernames };
 }

--- a/src/utils/orgUtils.ts
+++ b/src/utils/orgUtils.ts
@@ -1,19 +1,90 @@
 import { execSfdxJson } from "../utils";
 
-export async function listOrgs() {
+export type SalesforceOrg = {
+    username?: string;
+    alias?: string;
+    orgType?: 'production' | 'sandbox' | 'scratch' | 'other' ;
+    isDefault?: boolean;
+    isScratch?: boolean;
+    isSandbox?: boolean;
+    instanceUrl?: string;
+    loginUrl?: string;
+    orgId?: string;
+    createdDate?: string;
+    expirationDate?: string | null;
+    connectedStatus?: string;
+    name?: string;
+};
+
+export async function listAllOrgs(all=false): Promise<SalesforceOrg[]> {
     // List all orgs
-    const orgList = await execSfdxJson("sf org list --all");
-    // For each org, add the org type (Production, Sandbox, Developer, Scratch), without calling SF Cli again
-    for (const org of orgList) {
-        if (org.isScratch) {
-            org.orgType = "Scratch";
-        } else if (org.instanceUrl.includes(".sandbox")) {
-            org.orgType = "Sandbox";
-        } else {
-            org.orgType = "Production";
+    const orgListRes = await execSfdxJson(`sf org list${all ? ' --all' : ''}`);
+
+    // orgListRes.result may contain several arrays grouped by type (other, sandboxes, nonScratchOrgs, devHubs, scratchOrgs, ...)
+    // We want to return a single flattened list of orgs. Deduplicate by orgId when present, otherwise by username.
+    const result = orgListRes?.result || {};
+
+    // Collect candidate arrays from the result object. If result is an array (older formats), use it directly.
+    const buckets: any[] = [];
+    if (Array.isArray(result)) {
+        buckets.push(...result);
+    } else if (typeof result === "object" && result !== null) {
+        for (const val of Object.values(result)) {
+            if (Array.isArray(val)) {
+                buckets.push(...val);
+            }
         }
     }
-    return orgList;
+    const seen = new Map<string, SalesforceOrg>();
+    for (const org of buckets) {
+        if (!org) {
+            continue;
+        }
+        const key = org.orgId || org.username || org.instanceUrl || JSON.stringify(org);
+        if (seen.has(key)) {
+            // already added (avoid duplicates)
+            continue;
+        }
+        // Determine org type
+        let orgType: 'production' | 'sandbox' | 'scratch' | 'other' = "other";
+        if (org.isScratch) {
+            orgType = "scratch";
+        } else if (org.isSandbox || (org.instanceUrl && org.instanceUrl.includes(".sandbox"))) {
+            orgType = "sandbox";
+        }
+        else if (!org.instanceUrl.includes("dev-ed") && !org.instanceUrl.includes("test") && !org.instanceUrl.includes("sandbox")) {
+            orgType = "production";
+        }
+        const normalized: SalesforceOrg = {
+            username: org.username,
+            alias: org.alias,
+            orgType: orgType,
+            isDefault: org.isDefault,
+            isScratch: !!org.isScratch,
+            isSandbox: !!org.isSandbox,
+            instanceUrl: org.instanceUrl,
+            loginUrl: org.loginUrl,
+            orgId: org.orgId,
+            createdDate: org.createdDate,
+            expirationDate: org.expirationDate || org.trailExpirationDate,
+            connectedStatus: org.connectedStatus,
+            name: org.name,
+        };
+        seen.set(key, normalized);
+    }
+
+    // Sort by orgType (production, sandbox, other, scratch), then by instanceUrl
+    const orgTypeOrder = { production: 0, sandbox: 1, other: 2, scratch: 3 };
+    return Array.from(seen.values()).sort((a, b) => {
+        const aType = orgTypeOrder[a.orgType || "other"];
+        const bType = orgTypeOrder[b.orgType || "other"];
+        if (aType !== bType) {
+            return aType - bType;
+        }
+        const aUrl = a.instanceUrl || "";
+        const bUrl = b.instanceUrl || "";
+        return aUrl.localeCompare(bUrl);
+    });
 }
 
 export async function forgetOrgs(orgUsernames: string[]) {

--- a/src/webviews/lwc-ui/index.js
+++ b/src/webviews/lwc-ui/index.js
@@ -14,6 +14,7 @@ const lwcModules = {
   "s-extension-config": () => import("s/extensionConfig"),
   "s-multiline-helptext": () => import("s/multilineHelptext"),
   "s-installed-packages": () => import("s/installedPackages"),
+  "s-org-manager": () => import("s/orgManager"),
 };
 
 // Communication bridge between VS Code webview and LWC components

--- a/src/webviews/lwc-ui/modules/s/orgManager/orgManager.css
+++ b/src/webviews/lwc-ui/modules/s/orgManager/orgManager.css
@@ -1,0 +1,8 @@
+.slds-m-around_medium {
+	margin: 1rem;
+}
+
+.blue-back {
+	background: #EDF4FF;
+	min-height: 100vh;
+}

--- a/src/webviews/lwc-ui/modules/s/orgManager/orgManager.html
+++ b/src/webviews/lwc-ui/modules/s/orgManager/orgManager.html
@@ -7,6 +7,8 @@
                 <span class="slds-m-left_x-small"></span>
                 <lightning-button icon-name="utility:refresh" label="Refresh" title="Refresh orgs list" onclick={handleRefresh}></lightning-button>
                 <span class="slds-m-left_x-small"></span>
+                <lightning-button icon-name="utility:add" label="Add Org" title="Connect to existing orgs" variant="brand" onclick={handleConnect}></lightning-button>
+                <span class="slds-m-left_x-small"></span>
                 <template if:true={hasRecommended}>
                     <lightning-button icon-name="utility:trash" label="Remove recommended" variant="destructive" title="Remove recommended orgs" onclick={handleRemoveRecommended}></lightning-button>
                 </template>

--- a/src/webviews/lwc-ui/modules/s/orgManager/orgManager.html
+++ b/src/webviews/lwc-ui/modules/s/orgManager/orgManager.html
@@ -3,7 +3,13 @@
     <lightning-card title="Salesforce Orgs Manager">
         <div slot="actions" class="slds-float_right">
             <lightning-button-group>
+                <lightning-input type="toggle" label="View all orgs" title="View all orgs" checked={viewAll} onchange={handleViewAllToggle}></lightning-input>
+                <span class="slds-m-left_x-small"></span>
                 <lightning-button icon-name="utility:refresh" label="Refresh" title="Refresh orgs list" onclick={handleRefresh}></lightning-button>
+                <span class="slds-m-left_x-small"></span>
+                <template if:true={hasRecommended}>
+                    <lightning-button icon-name="utility:trash" label="Remove recommended" variant="destructive" title="Remove recommended orgs" onclick={handleRemoveRecommended}></lightning-button>
+                </template>
                 <span class="slds-m-left_x-small"></span>
                 <template if:true={hasSelection}>
                     <lightning-button icon-name="utility:delete" label="Forget selected" variant="destructive" title="Forget selected orgs" onclick={handleForgetSelected}></lightning-button>
@@ -15,7 +21,6 @@
                 key-field="username"
                 data={orgs}
                 columns={columns}
-                onsave={handleSave}
                 onrowaction={handleRowAction}
                 onrowselection={handleRowSelection}
                 selected-rows={selectedRowKeys}

--- a/src/webviews/lwc-ui/modules/s/orgManager/orgManager.html
+++ b/src/webviews/lwc-ui/modules/s/orgManager/orgManager.html
@@ -1,0 +1,27 @@
+<template>
+    <div class="slds-scope slds-theme_default slds-p-around_medium blue-back">
+    <lightning-card title="Salesforce Orgs Manager">
+        <div slot="actions" class="slds-float_right">
+            <lightning-button-group>
+                <lightning-button icon-name="utility:refresh" label="Refresh" title="Refresh orgs list" onclick={handleRefresh}></lightning-button>
+                <span class="slds-m-left_x-small"></span>
+                <template if:true={hasSelection}>
+                    <lightning-button icon-name="utility:delete" label="Forget selected" variant="destructive" title="Forget selected orgs" onclick={handleForgetSelected}></lightning-button>
+                </template>
+            </lightning-button-group>
+        </div>
+        <div class="slds-m-around_medium">
+            <lightning-datatable
+                key-field="username"
+                data={orgs}
+                columns={columns}
+                onsave={handleSave}
+                onrowaction={handleRowAction}
+                onrowselection={handleRowSelection}
+                selected-rows={selectedRowKeys}
+                class="slds-m-bottom_medium"
+            ></lightning-datatable>
+        </div>
+    </lightning-card>
+    </div>
+</template>

--- a/src/webviews/lwc-ui/modules/s/orgManager/orgManager.js
+++ b/src/webviews/lwc-ui/modules/s/orgManager/orgManager.js
@@ -1,0 +1,103 @@
+import { LightningElement, api, track } from "lwc";
+
+export default class OrgManager extends LightningElement {
+  @track orgs = [];
+  @track selectedRowKeys = [];
+
+  columns = [
+    { label: "Instance URL", fieldName: "instanceUrl", type: "url", typeAttributes: { label: { fieldName: 'instanceUrl' }, target: '_blank' } },
+    { label: "Username", fieldName: "username", type: "text" },
+    {
+      label: "Connected",
+      fieldName: "connectedStatus",
+      type: "button",
+      typeAttributes: {
+        label: { fieldName: 'connectedLabel' },
+        name: 'toggleConnection',
+        variant: { fieldName: 'connectedVariant' }
+      }
+    },
+    {
+      label: "Action",
+      type: "button",
+      typeAttributes: {
+        label: 'Open in Browser',
+        name: 'openLoginUrl',
+        variant: 'neutral'
+      }
+    }
+  ];
+
+  get hasSelection() {
+    return this.selectedRowKeys && this.selectedRowKeys.length > 0;
+  }
+
+  @api
+  initialize(data) {
+    this.orgs = (data && data.orgs) || [];
+    // Normalize rows: compute connected label/variant and ensure username exists as key
+    this.orgs = this.orgs.map((o) => ({
+      ...o,
+      username: o.username || o.loginUrl || o.instanceUrl,
+      connectedLabel: o.connectedStatus && o.connectedStatus.toLowerCase().startsWith('connected') ? 'Disconnect' : 'Reconnect',
+      connectedVariant: o.connectedStatus && o.connectedStatus.toLowerCase().startsWith('connected') ? 'destructive' : 'brand'
+    }));
+    this.selectedRowKeys = [];
+  }
+
+  @api
+  handleMessage(messageType, data) {
+    switch (messageType) {
+      case 'refreshOrgs':
+        this.handleRefresh();
+        break;
+      default:
+        console.log('Unknown message type:', messageType, data);
+    }
+  }
+
+  handleRefresh() {
+    if (typeof window !== 'undefined' && window.sendMessageToVSCode) {
+      window.sendMessageToVSCode({ type: 'refreshOrgs' });
+    }
+  }
+
+  handleRowSelection(event) {
+    const selectedRows = event.detail.selectedRows || [];
+    this.selectedRowKeys = selectedRows.map((r) => r.username);
+  }
+
+  handleForgetSelected() {
+    if (!this.hasSelection) return;
+    if (typeof window !== 'undefined' && window.sendMessageToVSCode) {
+      window.sendMessageToVSCode({ type: 'forgetOrgs', data: { usernames: this.selectedRowKeys } });
+    }
+  }
+
+  handleRowAction(event) {
+    const actionName = event.detail.action.name;
+    const row = event.detail.row;
+    if (actionName === 'toggleConnection') {
+      // If currently connected, call logout; otherwise, try to login (open login URL)
+      const isConnected = row.connectedStatus && row.connectedStatus.toLowerCase().startsWith('connected');
+      if (isConnected) {
+        // Logout
+        if (typeof window !== 'undefined' && window.sendMessageToVSCode) {
+          window.sendMessageToVSCode({ type: 'runCommand', data: { command: `sf org logout --target-org ${row.username} --noprompt` } });
+        }
+      } else {
+        // Reconnect: open browser login
+        if (typeof window !== 'undefined' && window.sendMessageToVSCode) {
+          // Prefer runCommand to open login flow; extension can handle this message
+          window.sendMessageToVSCode({ type: 'runCommand', data: { command: `sf org login web --instance-url ${row.instanceUrl} --username ${row.username}` } });
+        }
+      }
+    } else if (actionName === 'openLoginUrl') {
+      // open loginUrl in external browser
+      const url = row.loginUrl || row.instanceUrl;
+      if (typeof window !== 'undefined' && window.sendMessageToVSCode) {
+        window.sendMessageToVSCode({ type: 'openUrl', data: { url } });
+      }
+    }
+  }
+}

--- a/src/webviews/lwc-ui/modules/s/orgManager/orgManager.js
+++ b/src/webviews/lwc-ui/modules/s/orgManager/orgManager.js
@@ -52,11 +52,20 @@ export default class OrgManager extends LightningElement {
     }
   }
 
-  handleRefresh(all = false) {
-    // Respect the explicit all flag, or the toggle state in the UI
-    const allFlag = all || this.viewAll === true;
+  handleConnect() {
     if (typeof window !== 'undefined' && window.sendMessageToVSCode) {
-      window.sendMessageToVSCode({ type: 'refreshOrgs', data: { all: allFlag } });
+      window.sendMessageToVSCode({ type: 'runCommand', data: { command: 'sf hardis:org:select --prompt-default' } });
+    }
+  }
+
+  handleRefresh(all = false) {
+    // If called as an event handler the first argument will be an Event object.
+    // Treat a non-boolean `all` argument as "no explicit flag" and fall back to the UI toggle.
+    const explicitAll = typeof all === 'boolean' ? all : undefined;
+    const allFlag = explicitAll === true ? true : this.viewAll === true;
+    if (typeof window !== 'undefined' && window.sendMessageToVSCode) {
+      // Always send a boolean for `all` so the backend can rely on `data.all === true` checks
+      window.sendMessageToVSCode({ type: 'refreshOrgs', data: { all: !!allFlag } });
     }
   }
 

--- a/src/webviews/lwc-ui/modules/s/orgManager/orgManager.js
+++ b/src/webviews/lwc-ui/modules/s/orgManager/orgManager.js
@@ -6,7 +6,15 @@ export default class OrgManager extends LightningElement {
   @track viewAll = false;
 
   columns = [
-    { label: "Instance URL", fieldName: "instanceUrl", type: "url", typeAttributes: { label: { fieldName: 'instanceLabel' }, target: '_blank' } },
+    {
+      label: "Instance URL",
+      fieldName: "instanceUrl",
+      type: "url",
+      typeAttributes: {
+        label: { fieldName: "instanceLabel" },
+        target: "_blank",
+      },
+    },
     { label: "Type", fieldName: "orgType", type: "text" },
     { label: "Username", fieldName: "username", type: "text" },
     {
@@ -14,11 +22,11 @@ export default class OrgManager extends LightningElement {
       fieldName: "connectedStatus",
       type: "button",
       typeAttributes: {
-        label: { fieldName: 'connectedLabel' },
-        name: 'toggleConnection',
-        variant: { fieldName: 'connectedVariant' }
-      }
-    }
+        label: { fieldName: "connectedLabel" },
+        name: "toggleConnection",
+        variant: { fieldName: "connectedVariant" },
+      },
+    },
   ];
 
   get hasSelection() {
@@ -33,10 +41,22 @@ export default class OrgManager extends LightningElement {
       ...o,
       username: o.username || o.loginUrl || o.instanceUrl,
       // strip protocol for display (label) and remove trailing slash
-      instanceLabel: (o.instanceUrl || '').replace(/^https?:\/\//, '').replace(/\/$/, ''),
+      instanceLabel: (o.instanceUrl || "")
+        .replace(/^https?:\/\//, "")
+        .replace(/\/$/, ""),
       // more robust connected detection: accept connected/authorized/true etc.
-      connectedLabel: (o.connectedStatus || '').toString().toLowerCase().match(/connected|authorized/) ? 'Disconnect' : 'Reconnect',
-      connectedVariant: (o.connectedStatus || '').toString().toLowerCase().match(/connected|authorized/) ? 'destructive' : 'brand'
+      connectedLabel: (o.connectedStatus || "")
+        .toString()
+        .toLowerCase()
+        .match(/connected|authorized/)
+        ? "Disconnect"
+        : "Reconnect",
+      connectedVariant: (o.connectedStatus || "")
+        .toString()
+        .toLowerCase()
+        .match(/connected|authorized/)
+        ? "destructive"
+        : "brand",
     }));
     this.selectedRowKeys = [];
   }
@@ -44,28 +64,34 @@ export default class OrgManager extends LightningElement {
   @api
   handleMessage(messageType, data) {
     switch (messageType) {
-      case 'refreshOrgs':
+      case "refreshOrgs":
         this.handleRefresh(data && data.all === true);
         break;
       default:
-        console.log('Unknown message type:', messageType, data);
+        console.log("Unknown message type:", messageType, data);
     }
   }
 
   handleConnect() {
-    if (typeof window !== 'undefined' && window.sendMessageToVSCode) {
-      window.sendMessageToVSCode({ type: 'runCommand', data: { command: 'sf hardis:org:select --prompt-default' } });
+    if (typeof window !== "undefined" && window.sendMessageToVSCode) {
+      window.sendMessageToVSCode({
+        type: "runCommand",
+        data: { command: "sf hardis:org:select --prompt-default" },
+      });
     }
   }
 
   handleRefresh(all = false) {
     // If called as an event handler the first argument will be an Event object.
     // Treat a non-boolean `all` argument as "no explicit flag" and fall back to the UI toggle.
-    const explicitAll = typeof all === 'boolean' ? all : undefined;
+    const explicitAll = typeof all === "boolean" ? all : undefined;
     const allFlag = explicitAll === true ? true : this.viewAll === true;
-    if (typeof window !== 'undefined' && window.sendMessageToVSCode) {
+    if (typeof window !== "undefined" && window.sendMessageToVSCode) {
       // Always send a boolean for `all` so the backend can rely on `data.all === true` checks
-      window.sendMessageToVSCode({ type: 'refreshOrgs', data: { all: !!allFlag } });
+      window.sendMessageToVSCode({
+        type: "refreshOrgs",
+        data: { all: !!allFlag },
+      });
     }
   }
 
@@ -84,8 +110,18 @@ export default class OrgManager extends LightningElement {
     const now = Date.now();
     return (this.orgs || [])
       .filter((o) => {
-        const connected = (o.connectedStatus || "").toString().toLowerCase().match(/connected|authorized/);
-        const deleted = o.deleted === true || o.isDeleted === true || (o.status || "").toString().toLowerCase().includes("deleted") || (o.connectedStatus || "").toString().toLowerCase().includes("deleted");
+        const connected = (o.connectedStatus || "")
+          .toString()
+          .toLowerCase()
+          .match(/connected|authorized/);
+        const deleted =
+          o.deleted === true ||
+          o.isDeleted === true ||
+          (o.status || "").toString().toLowerCase().includes("deleted") ||
+          (o.connectedStatus || "")
+            .toString()
+            .toLowerCase()
+            .includes("deleted");
         let expired = false;
         try {
           if (o.expirationDate) {
@@ -95,7 +131,7 @@ export default class OrgManager extends LightningElement {
         } catch (e) {
           // ignore date parse errors
         }
-        return (!connected) || deleted || expired;
+        return !connected || deleted || expired;
       })
       .map((o) => o.username)
       .filter(Boolean);
@@ -104,8 +140,11 @@ export default class OrgManager extends LightningElement {
   handleRemoveRecommended() {
     const recommendedUsernames = this.recommendedUsernames || [];
 
-    if (typeof window !== 'undefined' && window.sendMessageToVSCode) {
-      window.sendMessageToVSCode({ type: 'removeRecommended', data: { usernames: recommendedUsernames } });
+    if (typeof window !== "undefined" && window.sendMessageToVSCode) {
+      window.sendMessageToVSCode({
+        type: "removeRecommended",
+        data: { usernames: recommendedUsernames },
+      });
     }
   }
 
@@ -118,8 +157,8 @@ export default class OrgManager extends LightningElement {
     // Try to gather usernames from tracked selection; if empty, fallback to the datatable's selected rows
     let usernames = (this.selectedRowKeys || []).slice();
     if (!usernames || usernames.length === 0) {
-      const table = this.template.querySelector('lightning-datatable');
-      if (table && typeof table.getSelectedRows === 'function') {
+      const table = this.template.querySelector("lightning-datatable");
+      if (table && typeof table.getSelectedRows === "function") {
         const rows = table.getSelectedRows() || [];
         usernames = rows.map((r) => r.username).filter(Boolean);
       }
@@ -129,31 +168,37 @@ export default class OrgManager extends LightningElement {
 
     // Debug: log the usernames we will send
     // eslint-disable-next-line no-console
-    console.log('OrgManager: forgetting selected usernames', usernames);
+    console.log("OrgManager: forgetting selected usernames", usernames);
 
-    if (typeof window !== 'undefined' && window.sendMessageToVSCode) {
-      window.sendMessageToVSCode({ type: 'forgetOrgs', data: { usernames } });
+    if (typeof window !== "undefined" && window.sendMessageToVSCode) {
+      window.sendMessageToVSCode({ type: "forgetOrgs", data: { usernames } });
     }
   }
 
   handleRowAction(event) {
     const actionName = event.detail.action.name;
     const row = event.detail.row;
-    if (actionName === 'toggleConnection') {
+    if (actionName === "toggleConnection") {
       // Robust connected detection using same regex as label computation
-      const isConnected = (row.connectedStatus || '').toString().toLowerCase().match(/connected|authorized/);
+      const isConnected = (row.connectedStatus || "")
+        .toString()
+        .toLowerCase()
+        .match(/connected|authorized/);
       if (isConnected) {
         // Use the same forget flow as the global "Forget selected" action so the extension
         // can show progress and handle cleanup consistently.
-        if (typeof window !== 'undefined' && window.sendMessageToVSCode) {
-          window.sendMessageToVSCode({ type: 'forgetOrgs', data: { usernames: [row.username] } });
+        if (typeof window !== "undefined" && window.sendMessageToVSCode) {
+          window.sendMessageToVSCode({
+            type: "forgetOrgs",
+            data: { usernames: [row.username] },
+          });
         }
       } else {
         // Reconnect: send a connectOrg message to the extension so it can
         // handle the connect flow (sf hardis:org:connect) centrally.
-        if (typeof window !== 'undefined' && window.sendMessageToVSCode) {
+        if (typeof window !== "undefined" && window.sendMessageToVSCode) {
           window.sendMessageToVSCode({
-            type: 'connectOrg',
+            type: "connectOrg",
             data: { username: row.username, instanceUrl: row.instanceUrl },
           });
         }


### PR DESCRIPTION
Introduces a new Orgs Manager feature to list, manage, and clean Salesforce orgs within the extension.

Key improvements:
- Provides a user interface to view and interact with known Salesforce orgs.
- Allows disconnecting from orgs.
- Enables removal of recommended orgs (disconnected, deleted, or expired).
- Improves org listing to display type and handle various org states.