### PR TITLE
Open org using SF Cli + Adds internal command execution with progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## [6.3.2] 2024-09-01
 
 - Open org using SF Cli + Adds internal command execution with progress
+- Fix issue when reusing an already open panel
 
 ## [6.3.1] 2024-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [6.3.2] 2024-09-01
+
+- Open org using SF Cli + Adds internal command execution with progress
+
 ## [6.3.1] 2024-09-01
 
 - Change icon of Orgs Manager

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -93,7 +93,7 @@ export class Commands {
           let currentAllFlag = false;
 
           panel.onMessage(async (type: string, data: any) => {
-            if (type === "refreshOrgs") {
+            if (type === "refreshOrgsFromUi") {
               const allFlag = !!(data && data.all === true);
               currentAllFlag = allFlag;
               const newOrgs = await this.loadOrgsWithProgress(allFlag);

--- a/src/lwc-panel-manager.ts
+++ b/src/lwc-panel-manager.ts
@@ -48,6 +48,9 @@ export class LwcPanelManager {
     // Check if panel already exists and is not disposed
     const existingPanel = this.activePanels.get(lwcId);
     if (existingPanel && !existingPanel.isDisposed()) {
+      // Remove existing onMessage handlers to avoid duplicates
+      existingPanel.clearExistingOnMessageListeners();
+
       // Panel exists, reveal it and update with new data if provided
       const column = vscode.window.activeTextEditor
         ? vscode.window.activeTextEditor.viewColumn

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -212,6 +212,7 @@ export async function execCommandWithProgress(
   );
 }
 
+/* jscpd-ignore-start */
 export async function execSfdxJsonWithProgress(
     command: string,
     options: ExecCommandOptions = {
@@ -233,6 +234,7 @@ export async function execSfdxJsonWithProgress(
     }
   );
 }
+/* jscpd-ignore-end */
 
 // Execute command
 export async function execCommand(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -190,6 +190,50 @@ export async function resetCache() {
   Logger.log("[vscode-sfdx-hardis] Reset cache");
 }
 
+export async function execCommandWithProgress(
+    command: string,
+    options: ExecCommandOptions = {
+      fail: false,
+      output: false,
+      debug: false,
+      spinner: true,
+    },
+    progressMessage: string)
+{
+  return await vscode.window.withProgress(
+    {
+      location: vscode.ProgressLocation.Notification,
+      title: progressMessage || "Executing command...",
+      cancellable: false,
+    },
+    async () => {
+      return await execCommand(command, options);
+    }
+  );
+}
+
+export async function execSfdxJsonWithProgress(
+    command: string,
+    options: ExecCommandOptions = {
+      fail: false,
+      output: false,
+      debug: false,
+      spinner: true,
+    },
+    progressMessage: string)
+{
+  return await vscode.window.withProgress(
+    {
+      location: vscode.ProgressLocation.Notification,
+      title: progressMessage || "Executing command...",
+      cancellable: false,
+    },
+    async () => {
+      return await execSfdxJson(command, options);
+    }
+  );
+}
+
 // Execute command
 export async function execCommand(
   command: string,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -212,7 +212,7 @@ export async function execCommandWithProgress(
   );
 }
 
-/* jscpd-ignore-start */
+/* jscpd:ignore-start */
 export async function execSfdxJsonWithProgress(
     command: string,
     options: ExecCommandOptions = {
@@ -234,7 +234,7 @@ export async function execSfdxJsonWithProgress(
     }
   );
 }
-/* jscpd-ignore-end */
+/* jscpd:ignore-end */
 
 // Execute command
 export async function execCommand(
@@ -519,7 +519,7 @@ export async function loadExternalSfdxHardisConfiguration() {
 }
 
 // Fetch remote config file
-/* jscpd-ignore-start */
+/* jscpd:ignore-start */
 async function loadFromRemoteConfigFile(url: string) {
   if (REMOTE_CONFIGS[url]) {
     return REMOTE_CONFIGS[url];
@@ -537,7 +537,7 @@ async function loadFromRemoteConfigFile(url: string) {
   REMOTE_CONFIGS[url] = remoteConfig;
   return remoteConfig;
 }
-/* jscpd-ignore-end */
+/* jscpd:ignore-end */
 
 export async function readSfdxHardisConfig(): Promise<any> {
   if (vscode.workspace.workspaceFolders) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -191,15 +191,15 @@ export async function resetCache() {
 }
 
 export async function execCommandWithProgress(
-    command: string,
-    options: ExecCommandOptions = {
-      fail: false,
-      output: false,
-      debug: false,
-      spinner: true,
-    },
-    progressMessage: string)
-{
+  command: string,
+  options: ExecCommandOptions = {
+    fail: false,
+    output: false,
+    debug: false,
+    spinner: true,
+  },
+  progressMessage: string,
+) {
   return await vscode.window.withProgress(
     {
       location: vscode.ProgressLocation.Notification,
@@ -208,21 +208,21 @@ export async function execCommandWithProgress(
     },
     async () => {
       return await execCommand(command, options);
-    }
+    },
   );
 }
 
 /* jscpd:ignore-start */
 export async function execSfdxJsonWithProgress(
-    command: string,
-    options: ExecCommandOptions = {
-      fail: false,
-      output: false,
-      debug: false,
-      spinner: true,
-    },
-    progressMessage: string)
-{
+  command: string,
+  options: ExecCommandOptions = {
+    fail: false,
+    output: false,
+    debug: false,
+    spinner: true,
+  },
+  progressMessage: string,
+) {
   return await vscode.window.withProgress(
     {
       location: vscode.ProgressLocation.Notification,
@@ -231,7 +231,7 @@ export async function execSfdxJsonWithProgress(
     },
     async () => {
       return await execSfdxJson(command, options);
-    }
+    },
   );
 }
 /* jscpd:ignore-end */

--- a/src/webviews/lwc-ui-panel.ts
+++ b/src/webviews/lwc-ui-panel.ts
@@ -210,6 +210,11 @@ export class LwcUiPanel {
     };
   }
 
+  public clearExistingOnMessageListeners(): void {
+    // Clear listeners previously added with onMessage method
+    this.messageListeners = [];
+  }
+
   /**
    * Handle built-in file operation messages from the webview
    * @param message The message received from the webview

--- a/src/webviews/lwc-ui-panel.ts
+++ b/src/webviews/lwc-ui-panel.ts
@@ -1,6 +1,10 @@
 import * as vscode from "vscode";
 import * as path from "path";
-import { execCommandWithProgress, execSfdxJsonWithProgress, isWebVsCode } from "../utils";
+import {
+  execCommandWithProgress,
+  execSfdxJsonWithProgress,
+  isWebVsCode,
+} from "../utils";
 import { Logger } from "../logger";
 
 type MessageListener = (messageType: string, data: any) => void;
@@ -287,13 +291,21 @@ export class LwcUiPanel {
     );
   }
 
-  private async handleRunInternalCommand(data: { command: string, commandId: number, progressMessage: string }): Promise<void> {
+  private async handleRunInternalCommand(data: {
+    command: string;
+    commandId: number;
+    progressMessage: string;
+  }): Promise<void> {
     if (!data || !data.command || typeof data.command !== "string") {
       vscode.window.showErrorMessage("No internal command specified to run.");
       return;
     }
     const command = data.command;
-    if ( !command.startsWith("sf ") || command.includes("&&") || command.includes("||")) {
+    if (
+      !command.startsWith("sf ") ||
+      command.includes("&&") ||
+      command.includes("||")
+    ) {
       vscode.window.showErrorMessage(
         "Only 'sfdx' or 'sf' commands can be run as internal commands.",
       );
@@ -304,8 +316,7 @@ export class LwcUiPanel {
     try {
       if (data.command.includes("--json")) {
         result = await execSfdxJsonWithProgress(command, {}, progressMessage);
-      }
-      else {
+      } else {
         result = await execCommandWithProgress(command, {}, progressMessage);
       }
     } catch (error) {
@@ -320,7 +331,6 @@ export class LwcUiPanel {
       },
     });
   }
-
 
   /**
    * Handle file existence check request from webview

--- a/src/webviews/lwc-ui-panel.ts
+++ b/src/webviews/lwc-ui-panel.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import * as path from "path";
-import { execCommand, execCommandWithProgress, execSfdxJson, execSfdxJsonWithProgress, isWebVsCode } from "../utils";
+import { execCommandWithProgress, execSfdxJsonWithProgress, isWebVsCode } from "../utils";
 import { Logger } from "../logger";
 
 type MessageListener = (messageType: string, data: any) => void;

--- a/src/webviews/lwc-ui/modules/s/orgManager/orgManager.html
+++ b/src/webviews/lwc-ui/modules/s/orgManager/orgManager.html
@@ -10,7 +10,7 @@
                 <lightning-button icon-name="utility:add" label="Add Org" title="Connect to existing orgs" variant="brand" onclick={handleConnect}></lightning-button>
                 <span class="slds-m-left_x-small"></span>
                 <template if:true={hasRecommended}>
-                    <lightning-button icon-name="utility:trash" label="Remove recommended" variant="destructive" title="Remove recommended orgs" onclick={handleRemoveRecommended}></lightning-button>
+                    <lightning-button icon-name="utility:recycle_bin_full" label="Remove recommended" variant="destructive" title="Remove recommended orgs" onclick={handleRemoveRecommended}></lightning-button>
                 </template>
                 <span class="slds-m-left_x-small"></span>
                 <template if:true={hasSelection}>

--- a/src/webviews/lwc-ui/modules/s/orgManager/orgManager.js
+++ b/src/webviews/lwc-ui/modules/s/orgManager/orgManager.js
@@ -15,9 +15,10 @@ export default class OrgManager extends LightningElement {
         target: "_blank",
       },
     },
-    { label: "Type", fieldName: "orgType", type: "text" },
-    { label: "Username", fieldName: "username", type: "text" },
-    { label: "Connected", fieldName: "connectedLabel", type: "text" },
+  { label: "Type", fieldName: "orgType", type: "text", initialWidth: 120 },
+  { label: "Username", fieldName: "username", type: "text" },
+  { label: "Alias", fieldName: "alias", type: "text", initialWidth: 120 },
+  { label: "Connected", fieldName: "connectedLabel", type: "text", initialWidth: 140 },
     {
       label: "Actions",
       type: "action",
@@ -39,6 +40,7 @@ export default class OrgManager extends LightningElement {
     this.orgs = this.orgs.map((o) => ({
       ...o,
       username: o.username || o.loginUrl || o.instanceUrl,
+      alias: o.alias || "",
       // strip protocol for display (label) and remove trailing slash
       instanceLabel: (o.instanceUrl || "")
         .replace(/^https?:\/\//, "")

--- a/src/webviews/lwc-ui/modules/s/orgManager/orgManager.js
+++ b/src/webviews/lwc-ui/modules/s/orgManager/orgManager.js
@@ -15,10 +15,15 @@ export default class OrgManager extends LightningElement {
         target: "_blank",
       },
     },
-  { label: "Type", fieldName: "orgType", type: "text", initialWidth: 120 },
-  { label: "Username", fieldName: "username", type: "text" },
-  { label: "Alias", fieldName: "alias", type: "text", initialWidth: 120 },
-  { label: "Connected", fieldName: "connectedLabel", type: "text", initialWidth: 140 },
+    { label: "Type", fieldName: "orgType", type: "text", initialWidth: 120 },
+    { label: "Username", fieldName: "username", type: "text" },
+    { label: "Alias", fieldName: "alias", type: "text", initialWidth: 120 },
+    {
+      label: "Connected",
+      fieldName: "connectedLabel",
+      type: "text",
+      initialWidth: 140,
+    },
     {
       label: "Actions",
       type: "action",
@@ -64,7 +69,11 @@ export default class OrgManager extends LightningElement {
         } else {
           actions.push({ label: "Reconnect", name: "reconnect" });
         }
-        actions.push({ label: "Remove", name: "remove", variant: "destructive" });
+        actions.push({
+          label: "Remove",
+          name: "remove",
+          variant: "destructive",
+        });
         return actions;
       })(),
     }));
@@ -192,21 +201,27 @@ export default class OrgManager extends LightningElement {
     if (actionName === "open") {
       if (typeof window !== "undefined" && window.sendMessageToVSCode) {
         window.sendMessageToVSCode({
-           type: "runInternalCommand",
-           data: {
+          type: "runInternalCommand",
+          data: {
             command: `sf org open --target-org ${row.username}`,
             commandId: Math.random(),
-            progressMessage: `Opening org ${row.username}...`
-          }
+            progressMessage: `Opening org ${row.username}...`,
+          },
         });
       }
     } else if (actionName === "reconnect") {
       if (typeof window !== "undefined" && window.sendMessageToVSCode) {
-        window.sendMessageToVSCode({ type: "connectOrg", data: { username: row.username, instanceUrl: row.instanceUrl } });
+        window.sendMessageToVSCode({
+          type: "connectOrg",
+          data: { username: row.username, instanceUrl: row.instanceUrl },
+        });
       }
     } else if (actionName === "remove") {
       if (typeof window !== "undefined" && window.sendMessageToVSCode) {
-        window.sendMessageToVSCode({ type: "forgetOrgs", data: { usernames: [row.username] } });
+        window.sendMessageToVSCode({
+          type: "forgetOrgs",
+          data: { usernames: [row.username] },
+        });
       }
     }
   }

--- a/src/webviews/lwc-ui/modules/s/orgManager/orgManager.js
+++ b/src/webviews/lwc-ui/modules/s/orgManager/orgManager.js
@@ -97,7 +97,7 @@ export default class OrgManager extends LightningElement {
     if (typeof window !== "undefined" && window.sendMessageToVSCode) {
       // Always send a boolean for `all` so the backend can rely on `data.all === true` checks
       window.sendMessageToVSCode({
-        type: "refreshOrgs",
+        type: "refreshOrgsFromUi",
         data: { all: !!allFlag },
       });
     }

--- a/src/webviews/lwc-ui/modules/s/orgManager/orgManager.js
+++ b/src/webviews/lwc-ui/modules/s/orgManager/orgManager.js
@@ -17,14 +17,13 @@ export default class OrgManager extends LightningElement {
     },
     { label: "Type", fieldName: "orgType", type: "text" },
     { label: "Username", fieldName: "username", type: "text" },
+    { label: "Connected", fieldName: "connectedLabel", type: "text" },
     {
-      label: "Connected",
-      fieldName: "connectedStatus",
-      type: "button",
+      label: "Actions",
+      type: "action",
+      fieldName: "rowActions",
       typeAttributes: {
-        label: { fieldName: "connectedLabel" },
-        name: "toggleConnection",
-        variant: { fieldName: "connectedVariant" },
+        rowActions: { fieldName: "rowActions" },
       },
     },
   ];
@@ -49,14 +48,23 @@ export default class OrgManager extends LightningElement {
         .toString()
         .toLowerCase()
         .match(/connected|authorized/)
-        ? "Disconnect"
-        : "Reconnect",
-      connectedVariant: (o.connectedStatus || "")
-        .toString()
-        .toLowerCase()
-        .match(/connected|authorized/)
-        ? "destructive"
-        : "brand",
+        ? "Connected"
+        : "Disconnected",
+      // Compute row actions for the Actions column: Open (connected), Reconnect (disconnected), Remove (always)
+      rowActions: (() => {
+        const isConnected = (o.connectedStatus || "")
+          .toString()
+          .toLowerCase()
+          .match(/connected|authorized/);
+        const actions = [];
+        if (isConnected) {
+          actions.push({ label: "Open", name: "open" });
+        } else {
+          actions.push({ label: "Reconnect", name: "reconnect" });
+        }
+        actions.push({ label: "Remove", name: "remove", variant: "destructive" });
+        return actions;
+      })(),
     }));
     this.selectedRowKeys = [];
   }
@@ -178,30 +186,25 @@ export default class OrgManager extends LightningElement {
   handleRowAction(event) {
     const actionName = event.detail.action.name;
     const row = event.detail.row;
-    if (actionName === "toggleConnection") {
-      // Robust connected detection using same regex as label computation
-      const isConnected = (row.connectedStatus || "")
-        .toString()
-        .toLowerCase()
-        .match(/connected|authorized/);
-      if (isConnected) {
-        // Use the same forget flow as the global "Forget selected" action so the extension
-        // can show progress and handle cleanup consistently.
-        if (typeof window !== "undefined" && window.sendMessageToVSCode) {
-          window.sendMessageToVSCode({
-            type: "forgetOrgs",
-            data: { usernames: [row.username] },
-          });
-        }
-      } else {
-        // Reconnect: send a connectOrg message to the extension so it can
-        // handle the connect flow (sf hardis:org:connect) centrally.
-        if (typeof window !== "undefined" && window.sendMessageToVSCode) {
-          window.sendMessageToVSCode({
-            type: "connectOrg",
-            data: { username: row.username, instanceUrl: row.instanceUrl },
-          });
-        }
+    // Handle Actions column events (open, reconnect, remove)
+    if (actionName === "open") {
+      if (typeof window !== "undefined" && window.sendMessageToVSCode) {
+        window.sendMessageToVSCode({
+           type: "runInternalCommand",
+           data: {
+            command: `sf org open --target-org ${row.username}`,
+            commandId: Math.random(),
+            progressMessage: `Opening org ${row.username}...`
+          }
+        });
+      }
+    } else if (actionName === "reconnect") {
+      if (typeof window !== "undefined" && window.sendMessageToVSCode) {
+        window.sendMessageToVSCode({ type: "connectOrg", data: { username: row.username, instanceUrl: row.instanceUrl } });
+      }
+    } else if (actionName === "remove") {
+      if (typeof window !== "undefined" && window.sendMessageToVSCode) {
+        window.sendMessageToVSCode({ type: "forgetOrgs", data: { usernames: [row.username] } });
       }
     }
   }

--- a/src/webviews/lwc-ui/modules/s/pipelineConfig/pipelineConfig.js
+++ b/src/webviews/lwc-ui/modules/s/pipelineConfig/pipelineConfig.js
@@ -36,7 +36,7 @@ export default class PipelineConfig extends LightningElement {
     const isBranch = this.isBranch;
     // configSchema is an object: { [key]: schema }
     const configSchema = this.configSchema || {};
-    /* jscpd-ignore-start */
+    /* jscpd:ignore-start */
     return (this.sections || [])
       .map((section) => {
         const entries = [];
@@ -236,7 +236,7 @@ export default class PipelineConfig extends LightningElement {
         };
       })
       .filter((section) => section.entries.length > 0);
-    /* jscpd-ignore-end */
+    /* jscpd:ignore-end */
   }
 
   handleEdit() {


### PR DESCRIPTION
Introduces functionality to execute internal commands with progress updates in the UI.

Adds `execCommandWithProgress` and `execSfdxJsonWithProgress` utility functions to display progress notifications during command execution.
Modifies the Org Manager LWC to use the new `runInternalCommand` message type to execute SFDX commands.
Updates the Org Manager UI to include an "Open" action that uses `sf org open` command.
