### PR TITLE
Adds unsecured connected apps diagnosis command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [6.4.0] 2024-09-06
+
+- Add command **Org Monitoring -> Unsecured Connected Apps**
+- Detect when there is a crash at the beginning of a sf hardis command, and display error on running LWC panel
+
 ## [6.3.5] 2024-09-04
 
 - Installed packages manager: allow to pre-input packages using org installed packages

--- a/src/command-runner.ts
+++ b/src/command-runner.ts
@@ -291,7 +291,7 @@ export class CommandRunner {
         closeProgress();
       }
     }
-    const stderrLines: string[] = []
+    const stderrLines: string[] = [];
 
     // Handle output and errors
     childProcess.stdout?.on("data", (data: any) => {
@@ -319,10 +319,13 @@ export class CommandRunner {
           type: "backgroundCommandEnded",
           data: {
             command: preprocessedCommand,
-            commandShort: preprocessedCommand.replace("sf ","").split("--")[0].trim(),
+            commandShort: preprocessedCommand
+              .replace("sf ", "")
+              .split("--")[0]
+              .trim(),
             exitCode: code,
-            stderrLines: stderrLines
-          }
+            stderrLines: stderrLines,
+          },
         });
       }, 3000);
     });

--- a/src/hardis-commands-provider.ts
+++ b/src/hardis-commands-provider.ts
@@ -605,6 +605,15 @@ export class HardisCommandsProvider
               "https://sfdx-hardis.cloudity.com/hardis/org/diagnose/releaseupdates/",
           },
           {
+            id: "hardis:org:diagnose:unsecure-connected-apps",
+            label: "Unsecured Connected Apps",
+            tooltip:
+              "List all Connected Apps that are unsecured (not installed or not Admin user pre-approved)",
+            command: "sf hardis:org:diagnose:unsecure-connected-apps",
+            helpUrl:
+              "https://sfdx-hardis.cloudity.com/hardis/org/diagnose/unsecure-connected-apps/",
+          },
+          {
             id: "org:diagnose:legacyapi",
             label: "Legacy API versions usage",
             tooltip: "Detects if deprected APIs are your in a production org",

--- a/src/lwc-panel-manager.ts
+++ b/src/lwc-panel-manager.ts
@@ -112,7 +112,8 @@ export class LwcPanelManager {
    * @param message The message object to send
    */
   public sendMessageToAllPanels(message: any): void {
-    this.activePanels.forEach((panel) => {
+    for (const activePanel of this.activePanels) {
+      const panel = activePanel[1];
       if (!panel.isDisposed() && typeof panel.sendMessage === "function") {
         try {
           panel.sendMessage(message);
@@ -120,7 +121,7 @@ export class LwcPanelManager {
           Logger.log("Error sending message to panel:\n" + JSON.stringify(err));
         }
       }
-    });
+    }
   }
 
   /**

--- a/src/themeUtils.ts
+++ b/src/themeUtils.ts
@@ -310,6 +310,10 @@ export class ThemeUtils {
         vscode: "eye-watch",
         hardis: "monitoring.svg",
       },
+      "hardis:org:diagnose:unsecure-connected-apps": {
+        vscode: "plug",
+        hardis: "extract.svg",
+      },
       "hardis:lint:access": { vscode: "law", hardis: "password.svg" },
       "hardis:lint:unusedmetadatas": { vscode: "law", hardis: "trash.svg" },
       "hardis:lint:metadatastatus": { vscode: "law", hardis: "flow.svg" },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,7 +14,7 @@ import { getConfig } from "./utils/pipeline/sfdxHardisConfig";
 
 export const RECOMMENDED_SFDX_CLI_VERSION = null; //"7.111.6";
 export const NODE_JS_MINIMUM_VERSION = 20.0;
-export const RECOMMENDED_MINIMAL_SFDX_HARDIS_VERSION: string = "6.1.5";
+export const RECOMMENDED_MINIMAL_SFDX_HARDIS_VERSION: string = "6.3.0";
 
 // Interface for execCommand and execSfdxJson options
 export interface ExecCommandOptions {

--- a/src/webviews/lwc-ui/modules/s/commandExecution/commandExecution.js
+++ b/src/webviews/lwc-ui/modules/s/commandExecution/commandExecution.js
@@ -1576,15 +1576,24 @@ ${resultMessage}`;
   }
 
   handleBackgroundCommandEnded(data) {
-    if (data?.exitCode > 0 && !this.isCompleted && data.commandShort === this.commandContext?.command) {
+    if (
+      data?.exitCode > 0 &&
+      !this.isCompleted &&
+      data.commandShort === this.commandContext?.command
+    ) {
       // If the background command ended with an error, and this command is still running, mark it as failed
-      const stderrLinesStr = data?.stderrLines ? data.stderrLines.join("\n") : "";
+      const stderrLinesStr = data?.stderrLines
+        ? data.stderrLines.join("\n")
+        : "";
       this.addLogLine({
         logType: "error",
         message: `Background command "${data.command}" failed with exit code ${data.exitCode}.\n${stderrLinesStr}`,
         timestamp: new Date(),
       });
-      this.completeCommand({ success: false, status: `Aborted (background command failed)` });
+      this.completeCommand({
+        success: false,
+        status: `Aborted (background command failed)`,
+      });
     }
   }
 }

--- a/src/webviews/lwc-ui/modules/s/commandExecution/commandExecution.js
+++ b/src/webviews/lwc-ui/modules/s/commandExecution/commandExecution.js
@@ -181,6 +181,9 @@ export default class CommandExecution extends LightningElement {
       case "downloadFileFromPanel":
         this.handleDownloadFileFromPanel(data);
         break;
+      case "backgroundCommandEnded":
+        this.handleBackgroundCommandEnded(data);
+        break;
       default:
         console.log("Unknown message type:", messageType, data);
     }
@@ -1570,5 +1573,18 @@ ${resultMessage}`;
     a.download = fileName;
     a.click();
     URL.revokeObjectURL(url);
+  }
+
+  handleBackgroundCommandEnded(data) {
+    if (data?.exitCode > 0 && !this.isCompleted && data.commandShort === this.commandContext?.command) {
+      // If the background command ended with an error, and this command is still running, mark it as failed
+      const stderrLinesStr = data?.stderrLines ? data.stderrLines.join("\n") : "";
+      this.addLogLine({
+        logType: "error",
+        message: `Background command "${data.command}" failed with exit code ${data.exitCode}.\n${stderrLinesStr}`,
+        timestamp: new Date(),
+      });
+      this.completeCommand({ success: false, status: `Aborted (background command failed)` });
+    }
   }
 }


### PR DESCRIPTION
Adds a new command to diagnose unsecured connected apps.

This change also addresses an issue where errors occurring at the start of a
command execution were not being displayed in the LWC panel.
It now ensures that errors are properly captured and displayed to the user.

It also sends background command ended messages to all panels to update status
and handle errors.
