### PR TITLE
Auto-collapses completed progress sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [6.6.1] 2024-09-20
+
 - Auto-collapse progress sections when they are completed.
 
 ## [6.6.0] 2024-09-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Auto-collapse progress sections when they are completed.
+
 ## [6.6.0] 2024-09-19
 
 - New command to start Salesforce CLI MCP server from VsCode SFDX Hardis

--- a/src/webviews/lwc-ui/modules/s/commandExecution/commandExecution.js
+++ b/src/webviews/lwc-ui/modules/s/commandExecution/commandExecution.js
@@ -543,6 +543,12 @@ export default class CommandExecution extends LightningElement {
     if (this.currentProgressSection && this.currentProgressSection.isActive) {
       this.currentProgressSection.isActive = false;
       this.currentProgressSection.endTime = new Date();
+      
+      // Auto-collapse the progress section when it ends, unless user has manually toggled it
+      if (!this.userSectionExpandState.hasOwnProperty(this.currentProgressSection.id)) {
+        this.userSectionExpandState[this.currentProgressSection.id] = false;
+      }
+      
       this.currentProgressSection = null;
     }
   }
@@ -1075,8 +1081,11 @@ ${resultMessage}`;
       // By default, question sections and progress sections are expanded, but user can collapse them
       if (this.userSectionExpandState.hasOwnProperty(section.id)) {
         isExpanded = this.userSectionExpandState[section.id];
-      } else if (section.isQuestion || isProgress) {
+      } else if (section.isQuestion) {
         isExpanded = true;
+      } else if (isProgress) {
+        // Progress sections are expanded when active, collapsed when ended (unless user manually toggled)
+        isExpanded = section.isActive === true;
       } else if (isSimple) {
         if (this.showEmbeddedPrompt) {
           isExpanded = isLatest;
@@ -1945,6 +1954,11 @@ ${resultMessage}`;
     if (this.currentProgressSection) {
       this.currentProgressSection.isActive = false;
       this.currentProgressSection.endTime = new Date();
+      
+      // Auto-collapse the progress section when it ends, unless user has manually toggled it
+      if (!this.userSectionExpandState.hasOwnProperty(this.currentProgressSection.id)) {
+        this.userSectionExpandState[this.currentProgressSection.id] = false;
+      }
     }
 
     // Deactivate all previous sections (stop their spinners)
@@ -2026,6 +2040,12 @@ ${resultMessage}`;
     this.currentProgressSection.isActive = false;
     this.currentProgressSection.endTime = new Date();
     this.currentProgressSection.estimatedRemainingTime = null; // Clear estimation
+    
+    // Auto-collapse the progress section when it ends, unless user has manually toggled it
+    if (!this.userSectionExpandState.hasOwnProperty(this.currentProgressSection.id)) {
+      this.userSectionExpandState[this.currentProgressSection.id] = false;
+    }
+    
     this.currentProgressSection = null;
 
     // Update the sections array to trigger reactivity

--- a/src/webviews/lwc-ui/modules/s/commandExecution/commandExecution.js
+++ b/src/webviews/lwc-ui/modules/s/commandExecution/commandExecution.js
@@ -543,12 +543,16 @@ export default class CommandExecution extends LightningElement {
     if (this.currentProgressSection && this.currentProgressSection.isActive) {
       this.currentProgressSection.isActive = false;
       this.currentProgressSection.endTime = new Date();
-      
+
       // Auto-collapse the progress section when it ends, unless user has manually toggled it
-      if (!this.userSectionExpandState.hasOwnProperty(this.currentProgressSection.id)) {
+      if (
+        !this.userSectionExpandState.hasOwnProperty(
+          this.currentProgressSection.id,
+        )
+      ) {
         this.userSectionExpandState[this.currentProgressSection.id] = false;
       }
-      
+
       this.currentProgressSection = null;
     }
   }
@@ -1954,9 +1958,13 @@ ${resultMessage}`;
     if (this.currentProgressSection) {
       this.currentProgressSection.isActive = false;
       this.currentProgressSection.endTime = new Date();
-      
+
       // Auto-collapse the progress section when it ends, unless user has manually toggled it
-      if (!this.userSectionExpandState.hasOwnProperty(this.currentProgressSection.id)) {
+      if (
+        !this.userSectionExpandState.hasOwnProperty(
+          this.currentProgressSection.id,
+        )
+      ) {
         this.userSectionExpandState[this.currentProgressSection.id] = false;
       }
     }
@@ -2040,12 +2048,16 @@ ${resultMessage}`;
     this.currentProgressSection.isActive = false;
     this.currentProgressSection.endTime = new Date();
     this.currentProgressSection.estimatedRemainingTime = null; // Clear estimation
-    
+
     // Auto-collapse the progress section when it ends, unless user has manually toggled it
-    if (!this.userSectionExpandState.hasOwnProperty(this.currentProgressSection.id)) {
+    if (
+      !this.userSectionExpandState.hasOwnProperty(
+        this.currentProgressSection.id,
+      )
+    ) {
       this.userSectionExpandState[this.currentProgressSection.id] = false;
     }
-    
+
     this.currentProgressSection = null;
 
     // Update the sections array to trigger reactivity


### PR DESCRIPTION
Improves user experience by automatically collapsing
progress sections once they are completed. This
behavior is only applied if the user hasn't manually
toggled the expand/collapse state of the section.
