### PR TITLE
fix: Include scratch orgs in Metadata Retriever org selection

### DIFF
--- a/src/commands/showMetadataRetriever.ts
+++ b/src/commands/showMetadataRetriever.ts
@@ -129,8 +129,9 @@ async function handleListOrgs(panel: LwcUiPanel) {
   const orgs = await listAllOrgs(false);
 
   // Filter connected orgs and find default from the connected list
+  // Include both regular orgs (connectedStatus: "Connected") and scratch orgs (status: "Active")
   const connectedOrgs = orgs.filter(
-    (org) => org.connectedStatus === "Connected",
+    (org) => org.connectedStatus === "Connected" || org.status === "Active",
   );
   const selectedOrg =
     connectedOrgs.find((org) => org.isDefaultUsername) || connectedOrgs[0];

--- a/src/utils/orgUtils.ts
+++ b/src/utils/orgUtils.ts
@@ -16,6 +16,7 @@ export type SalesforceOrg = {
   createdDate?: string;
   expirationDate?: string | null;
   connectedStatus?: string;
+  status?: string; // For scratch orgs: "Active" | "Expired" | "Deleted"
   name?: string;
 };
 
@@ -80,6 +81,7 @@ export async function listAllOrgs(all = false): Promise<SalesforceOrg[]> {
       createdDate: org.createdDate,
       expirationDate: org.expirationDate || org.trailExpirationDate,
       connectedStatus: org.connectedStatus,
+      status: org.status, // Pass through scratch org status
       name: org.name,
     };
     seen.set(key, normalized);


### PR DESCRIPTION
## 🎯 Problem Statement

While working with the excellent SFDX Hardis extension, we discovered that scratch orgs weren't appearing in the Metadata Retriever's org selection dropdown. This was limiting our development workflow, especially when working with scratch orgs for feature development and testing.

After investigation, we found that the filtering logic only checked for `connectedStatus === "Connected"`, which works perfectly for regular orgs (production, sandboxes) but excludes scratch orgs entirely. Scratch orgs use a different property: `status` with values like "Active", "Expired", or "Deleted".

## ✨ Solution

We've implemented a targeted fix that extends the org filtering logic to support both org types:

### Changes Made:
1. **Type Definition Enhancement** (`src/utils/orgUtils.ts`)
   - Added `status?: string` property to the `SalesforceOrg` interface
   - Documented the scratch org status values: "Active" | "Expired" | "Deleted"

2. **Data Flow Fix** (`src/utils/orgUtils.ts`)
   - Ensured the `status` property is properly passed through from raw org data to normalized `SalesforceOrg` objects
   - Added inline comment for clarity: `status: org.status, // Pass through scratch org status`

3. **Filter Logic Update** (`src/commands/showMetadataRetriever.ts`)
   - Enhanced the org filter to include both regular and scratch orgs
   - Updated condition: `org.connectedStatus === "Connected" || org.status === "Active"`
   - Added explanatory comment for future maintainers

### Why This Approach?
We chose a simple OR-based filter because:
- ✅ It's clear and maintainable
- ✅ No breaking changes to existing functionality
- ✅ Minimal code footprint
- ✅ Expired/deleted scratch orgs are naturally filtered out
- ✅ Regular orgs continue to work exactly as before

## 🧪 Testing

**Expected Behavior:**
- ✅ Active scratch orgs now appear in the Metadata Retriever dropdown
- ✅ Expired and deleted scratch orgs are correctly filtered out
- ✅ Regular connected orgs continue to work without any changes
- ✅ The default org selection logic remains intact

**Impact Assessment:**
- **Risk Level:** Low
- **Breaking Changes:** None
- **Backward Compatibility:** Full

## 🙏 Acknowledgments

First, we want to express our sincere gratitude for creating and maintaining SFDX Hardis! It has become an essential tool in our Salesforce development workflow. The Metadata Retriever feature is particularly brilliant, and we're excited to make it even more useful by adding scratch org support.

We hope this contribution helps other teams who work extensively with scratch orgs during their development cycles.

Best regards,  
**Edwin & Riekus**  
Welisa Team 🚀

---

*P.S. If there's anything we can adjust or improve in this PR, please let us know. We're happy to iterate!*
