### PR TITLE
Fixes click on Commit changes button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## [Unreleased]
 
+## [6.16.4] 2024-11-03
+
 - Displays selected item count in multiselect
+- DevOps Pipeline: fix click on Commit changes
 
 ## [6.16.3] 2024-11-02
 

--- a/src/webviews/lwc-ui/modules/s/pipeline/pipeline.js
+++ b/src/webviews/lwc-ui/modules/s/pipeline/pipeline.js
@@ -846,6 +846,13 @@ export default class Pipeline extends LightningElement {
     });
   }
 
+  handleOpenMetadataRetriever() {
+    window.sendMessageToVSCode({
+      type: "showMetadataRetriever",
+      data: {},
+    });
+  }
+
   handleSaveUserStory() {
     window.sendMessageToVSCode({
       type: "runCommand",


### PR DESCRIPTION
Adds an event handler to display the metadata retriever, resolving an issue where clicking the "Commit changes" button in the DevOps Pipeline was not functioning as expected.

Fixes https://github.com/hardisgroupcom/sfdx-hardis/issues/1507