### PR TITLE
Fixes mermaid node name sanitization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fix mermaid node name sanitization to avoid multiple consecutive hyphens (mermaid crashes in that case)
+
 ## [6.17.0] 2024-11-09
 
 - Live DevOps Pipeline: UI part for deployment actions

--- a/src/utils/pipeline/branchStrategyMermaidBuilder.ts
+++ b/src/utils/pipeline/branchStrategyMermaidBuilder.ts
@@ -656,6 +656,7 @@ export class BranchStrategyMermaidBuilder {
     return branchName
       .replace(/[^a-zA-Z0-9_-]/g, "_") // Replace special chars with underscore
       .replace(/_{2,}/g, "_") // Replace multiple underscores with single
-      .replace(/^_+|_+$/g, ""); // Remove leading/trailing underscores
+      .replace(/^_+|_+$/g, "") // Remove leading/trailing underscores
+      .replace(/-+/g, "-"); // Replace multiple hyphens with single
   }
 }


### PR DESCRIPTION
Mermaid diagrams crash when node names contain multiple consecutive hyphens.

This change sanitizes node names to replace multiple hyphens with a single hyphen, preventing the crash.
