### PR TITLE
Filters non-retrievable metadata types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Metadata Retriever: Filter metadatas types that are not retrievable (ex: `PicklistValue`)
+
 ## [6.20.0] 2025-11-25
 
 - Prompts to disable TLS for certificate issues

--- a/src/commands/showMetadataRetriever.ts
+++ b/src/commands/showMetadataRetriever.ts
@@ -907,10 +907,15 @@ async function handleSourceMemberQuery(
 
   if (result && result.result && result.result.records) {
     let records = result.result.records as any[];
+    // Fix MemberName for certain types if needed
     records = records.map((r) => {
-      // Fix MemberName for certain types if needed
       r.MemberName = fixMemberName(r.MemberName, r.MemberType);
       return r;
+    });
+    // Filter Metadata Types that are not retrievable via Metadata API
+    const nonRetrievableTypes = ["PicklistValue"];
+    records = records.filter((r) => {
+      return !nonRetrievableTypes.includes(r.MemberType);
     });
     // Apply packageFilter post-query if provided
     if (packageFilter && packageFilter !== "All") {


### PR DESCRIPTION
Ensures that the Metadata Retriever only displays metadata types that can be retrieved, such as excluding `PicklistValue`. This prevents errors and improves the user experience by only showing valid options.
