### PR TITLE
Handles Data Cloud query display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Handle display of data cloud queries in command execution LWC
+
 ## [6.21.0] 2025-12-21
 
 - Metadata Retriever: Add option to retrieve metadatas in a specific local sfdx package folder

--- a/src/webviews/lwc-ui/modules/s/commandExecution/commandExecution.js
+++ b/src/webviews/lwc-ui/modules/s/commandExecution/commandExecution.js
@@ -454,7 +454,8 @@ export default class CommandExecution extends LightningElement {
     const isQueryOrResult =
       logLine.message.includes("[SOQL Query]") ||
       logLine.message.includes("[BulkApiV2]") ||
-      logLine.message.includes("[SOQL Query Tooling]");
+      logLine.message.includes("[SOQL Query Tooling]") ||
+      logLine.message.includes("[DataCloudSqlQuery]");
 
     if (isQueryOrResult) {
       // Clean up the message for queries
@@ -462,6 +463,7 @@ export default class CommandExecution extends LightningElement {
         .replace(/\[SOQL Query\]/g, "")
         .replace(/\[BulkApiV2\]/g, "")
         .replace(/\[SOQL Query Tooling\]/g, "")
+        .replace(/\[DataCloudSqlQuery\]/g, "")
         .trim();
     }
 


### PR DESCRIPTION
Ensures that Data Cloud SQL queries are properly displayed in the command execution LWC by adding logic to identify and clean up messages containing "[DataCloudSqlQuery]".
