### PR TITLE
Adds Object Field Usage monitoring command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix startup error message
 - Add capability to debug internal sfdx-hardis commands by setting `vsCodeSfdxHardis.debugSfdxHardisCommands` to true
 - Implement Data Workbench
+- Add monitoring command: [Object Field Usage](https://sfdx-hardis.cloudity.com/hardis/doc/object-field-usage/)
 
 ## [6.22.1] 2025-12-27
 

--- a/src/hardis-commands-provider.ts
+++ b/src/hardis-commands-provider.ts
@@ -828,6 +828,16 @@ export class HardisCommandsProvider
             helpUrl:
               "https://sfdx-hardis.cloudity.com/hardis/misc/custom-label-translations/",
           },
+          {
+            id: "hardis:doc:object-field-usage",
+            label: "Object Field Usage",
+            tooltip:
+              "Analyze object fields usage and produce a documentation report for cleanup decisions",
+            command: "sf hardis:doc:object-field-usage",
+            requiresProject: true,
+            helpUrl:
+              "https://sfdx-hardis.cloudity.com/hardis/doc/object/field/usage/",
+          },
         ],
       },
       {

--- a/src/themeUtils.ts
+++ b/src/themeUtils.ts
@@ -358,6 +358,7 @@ export class ThemeUtils {
         vscode: "law",
         hardis: "extract.svg",
       },
+      "hardis:doc:object-field-usage": { vscode: "table", hardis: "doc.svg" },
       "hardis:project:metadata:activate-decomposed": {
         vscode: "symbol-misc",
         hardis: "configure.svg",

--- a/src/webviews/lwc-ui/modules/s/orgMonitoring/orgMonitoring.html
+++ b/src/webviews/lwc-ui/modules/s/orgMonitoring/orgMonitoring.html
@@ -362,6 +362,23 @@
                         ></lightning-button>
                     </div>
 
+                    <!-- Object Field Usage -->
+                    <div class="command-card">
+                        <div class="command-header">
+                            <div class="command-icon-container metadata-access">
+                                <lightning-icon icon-name="utility:table" size="small" variant="inverse"></lightning-icon>
+                            </div>
+                            <h3 class="command-title">Object Field Usage</h3>
+                        </div>
+                        <p class="command-description">Analyze object fields usage and produce a cleanup report</p>
+                        <lightning-button 
+                            variant="outline-brand" 
+                            label="Analyze Fields" 
+                            onclick={runObjectFieldUsage}
+                            class="command-button"
+                        ></lightning-button>
+                    </div>
+
                     <!-- Unused Metadata -->
                     <div class="command-card">
                         <div class="command-header">

--- a/src/webviews/lwc-ui/modules/s/orgMonitoring/orgMonitoring.js
+++ b/src/webviews/lwc-ui/modules/s/orgMonitoring/orgMonitoring.js
@@ -216,6 +216,15 @@ export default class OrgMonitoring extends LightningElement {
     });
   }
 
+  runObjectFieldUsage() {
+    window.sendMessageToVSCode({
+      type: "runCommand",
+      data: {
+        command: "sf hardis:doc:object-field-usage",
+      },
+    });
+  }
+
   findUnusedMetadata() {
     window.sendMessageToVSCode({
       type: "runCommand",


### PR DESCRIPTION
Adds a new command to the org monitoring webview that analyzes object fields usage and produces a documentation report for cleanup decisions.
This feature allows users to identify unused fields, aiding in org simplification and maintenance.
