### PR TITLE
Add typeahead combobox to Metadata Retriever and improve org selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Metadata Retriever: the Metadata Type filter is now a searchable combobox — start typing to filter the list instead of scrolling through every type
+- Org selector: when several users are connected to the same org, each one is now listed separately instead of being collapsed into a single entry
+  - Orgs are now shown by their alias when available, making them easier to recognize at a glance
+
 ## [7.12.0] 2026-06-21
 
 - Add **Rotate External Client App credentials** action in Org Manager

--- a/src/utils/orgUtils.ts
+++ b/src/utils/orgUtils.ts
@@ -54,7 +54,7 @@ export async function listAllOrgs(
       continue;
     }
     const key =
-      org.orgId || org.username || org.instanceUrl || JSON.stringify(org);
+      org.username || org.orgId || org.instanceUrl || JSON.stringify(org);
     if (seen.has(key)) {
       // already added (avoid duplicates)
       continue;

--- a/src/webviews/lwc-ui/modules/s/metadataRetriever/metadataRetriever.html
+++ b/src/webviews/lwc-ui/modules/s/metadataRetriever/metadataRetriever.html
@@ -46,16 +46,16 @@
       <!-- Filters Section -->
       <div class="slds-p-around_x-small">
         <div class="slds-grid slds-gutters_x-small slds-wrap">
-          <!-- Metadata Type Filter -->
+          <!-- Metadata Type Filter (typeahead: filter the list by typing) -->
           <div class="slds-col slds-size_1-of-1 slds-medium-size_1-of-3 slds-large-size_1-of-6">
-            <lightning-combobox
+            <s-typeahead
               label={i18n.metadataTypeLabel}
               value={metadataType}
               options={metadataTypeOptions}
               onchange={handleMetadataTypeChange}
               placeholder={i18n.selectMetadataType}
               required={isAllMetadataMode}
-            ></lightning-combobox>
+            ></s-typeahead>
           </div>
 
           <!-- Folder Filter (only for foldered types in All Metadata mode) -->

--- a/src/webviews/lwc-ui/modules/s/metadataRetriever/metadataRetriever.js
+++ b/src/webviews/lwc-ui/modules/s/metadataRetriever/metadataRetriever.js
@@ -199,13 +199,14 @@ export default class MetadataRetriever extends SharedMixin(LightningElement) {
       return [];
     }
     const formatLabel = (org) => {
+      if(org.alias) return org.alias;
       if (org.instanceUrl) {
         return org.instanceUrl
           .replace(/^https?:\/\//i, "")
           .replace(/\/$/, "")
           .replace(/\.my\.salesforce\.com$/i, "");
       }
-      return org.alias || org.username;
+      return org.username;
     };
 
     const sortedOrgs = [...this.orgs].sort((a, b) => {

--- a/src/webviews/lwc-ui/modules/s/typeahead/typeahead.css
+++ b/src/webviews/lwc-ui/modules/s/typeahead/typeahead.css
@@ -1,0 +1,15 @@
+/* Ensure the typeahead dropdown floats above neighbouring form controls and
+   is not clipped by the surrounding grid columns. */
+.slds-combobox_container {
+  width: 100%;
+}
+
+.slds-dropdown {
+  z-index: 9001;
+}
+
+/* The right-hand arrow is decorative: let clicks fall through to the input so
+   tapping the arrow area opens the dropdown. */
+.slds-input__icon_right {
+  pointer-events: none;
+}

--- a/src/webviews/lwc-ui/modules/s/typeahead/typeahead.html
+++ b/src/webviews/lwc-ui/modules/s/typeahead/typeahead.html
@@ -1,0 +1,121 @@
+<template>
+  <div class={formElementClass}>
+    <label class={computedLabelClass} for={inputId}>
+      <template if:true={required}>
+        <abbr class="slds-required" title={requiredLabel}>*</abbr>
+      </template>
+      {label}
+    </label>
+    <div class="slds-form-element__control">
+      <div class="slds-combobox_container">
+        <div
+          class={comboboxClass}
+          aria-expanded={ariaExpanded}
+          aria-haspopup="listbox"
+          role="combobox"
+        >
+          <div
+            class="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
+            role="none"
+          >
+            <input
+              type="text"
+              id={inputId}
+              class="slds-input slds-combobox__input"
+              role="textbox"
+              autocomplete="off"
+              aria-autocomplete="list"
+              aria-controls={listboxId}
+              aria-describedby={ariaDescribedBy}
+              aria-invalid={ariaInvalid}
+              aria-required={ariaRequired}
+              placeholder={placeholder}
+              value={inputValue}
+              disabled={disabled}
+              required={required}
+              onfocus={handleFocus}
+              onclick={handleClick}
+              oninput={handleInput}
+              onblur={handleBlur}
+              onkeydown={handleKeydown}
+            />
+            <span
+              class="slds-icon_container slds-icon-utility-down slds-input__icon slds-input__icon_right"
+            >
+              <lightning-icon
+                icon-name="utility:down"
+                size="xx-small"
+                alternative-text={label}
+                class="slds-icon slds-icon_x-small slds-icon-text-default"
+              ></lightning-icon>
+            </span>
+          </div>
+          <template if:true={showDropdown}>
+            <div
+              id={listboxId}
+              class="slds-dropdown slds-dropdown_length-with-icon-7 slds-dropdown_fluid"
+              role="listbox"
+            >
+              <ul
+                class="slds-listbox slds-listbox_vertical"
+                role="presentation"
+              >
+                <template for:each={filteredOptions} for:item="opt">
+                  <li
+                    key={opt.key}
+                    role="presentation"
+                    class="slds-listbox__item"
+                    data-value={opt.value}
+                    onmousedown={handleOptionMouseDown}
+                  >
+                    <div
+                      class={opt.optionClass}
+                      role="option"
+                      aria-selected={opt.ariaSelected}
+                    >
+                      <span
+                        class="slds-media__figure slds-listbox__option-icon"
+                      >
+                        <template if:true={opt.selected}>
+                          <lightning-icon
+                            icon-name="utility:check"
+                            size="x-small"
+                            class="slds-icon slds-icon_x-small slds-icon-text-default"
+                          ></lightning-icon>
+                        </template>
+                      </span>
+                      <span class="slds-media__body">
+                        <span class="slds-truncate" title={opt.label}
+                          >{opt.label}</span
+                        >
+                      </span>
+                    </div>
+                  </li>
+                </template>
+                <template if:true={hasNoMatches}>
+                  <li role="presentation" class="slds-listbox__item">
+                    <div
+                      class="slds-media slds-listbox__option slds-listbox__option_plain slds-media_small"
+                      role="presentation"
+                    >
+                      <span class="slds-media__body">
+                        <span class="slds-truncate slds-text-color_weak"
+                          >{noMatchesLabel}</span
+                        >
+                      </span>
+                    </div>
+                  </li>
+                </template>
+              </ul>
+            </div>
+          </template>
+        </div>
+      </div>
+    </div>
+    <template if:true={showValidationError}>
+      <div id={errorMessageId} class="slds-form-element__help">
+        {validationMessage}
+      </div>
+    </template>
+  </div>
+</template>

--- a/src/webviews/lwc-ui/modules/s/typeahead/typeahead.js
+++ b/src/webviews/lwc-ui/modules/s/typeahead/typeahead.js
@@ -1,0 +1,404 @@
+import { LightningElement, api, track } from "lwc";
+import { SharedMixin } from "s/sharedMixin";
+
+/**
+ * Reusable typeahead combobox.
+ *
+ * Behaves like a dropdown (lightning-combobox) but lets the user type to
+ * filter the available options. API-compatible with the subset of
+ * lightning-combobox used across the extension: `label`, `value`, `options`,
+ * `placeholder`, `required`, `disabled`, `variant` ("label-hidden") and a
+ * `change` event whose detail carries the selected `value`.
+ */
+
+// Monotonic counter to build unique element ids (deterministic, no Math.random)
+let TYPEAHEAD_UID = 0;
+
+export default class Typeahead extends SharedMixin(LightningElement) {
+  @api label;
+  @api placeholder = "";
+  @api required = false;
+  @api disabled = false;
+  @api variant; // "label-hidden" is supported
+  @api name;
+
+  @track _options = [];
+  @track _value = null;
+  @track _searchTerm = "";
+  @track _open = false;
+  // True once the user has typed since focusing (controls show-all vs filter)
+  @track _dirty = false;
+  // Index of the keyboard-highlighted option within filteredOptions
+  @track _activeIndex = -1;
+  @track _showValidationError = false;
+  @track _validationMessage = "";
+
+  _uid = `typeahead-${TYPEAHEAD_UID++}`;
+  _blurTimer = null;
+  _customValidityMessage = "";
+
+  @api
+  get options() {
+    return this._options;
+  }
+  set options(val) {
+    this._options = Array.isArray(val) ? val : [];
+    // Keep the displayed text in sync with the selected value when the option
+    // list arrives/changes and the user is not actively typing.
+    if (!this._open) {
+      this._searchTerm = this.labelForValue(this._value);
+    }
+  }
+
+  @api
+  get value() {
+    return this._value;
+  }
+  set value(val) {
+    this._value = val === undefined ? null : val;
+    if (!this._open) {
+      this._searchTerm = this.labelForValue(this._value);
+    }
+    this.refreshVisibleValidity();
+  }
+
+  labelForValue(val) {
+    if (val === null || val === undefined || val === "") {
+      return "";
+    }
+    const found = this._options.find((opt) => opt && opt.value === val);
+    return found ? found.label : "";
+  }
+
+  // --- Template getters -----------------------------------------------------
+
+  get inputId() {
+    return `${this._uid}-input`;
+  }
+
+  get listboxId() {
+    return `${this._uid}-listbox`;
+  }
+
+  get inputValue() {
+    return this._searchTerm;
+  }
+
+  get requiredLabel() {
+    return this.t("requiredField");
+  }
+
+  get formElementClass() {
+    return this._showValidationError
+      ? "slds-form-element slds-has-error"
+      : "slds-form-element";
+  }
+
+  get errorMessageId() {
+    return `${this._uid}-error`;
+  }
+
+  get showValidationError() {
+    return this._showValidationError && !!this._validationMessage;
+  }
+
+  get validationMessage() {
+    return this._validationMessage;
+  }
+
+  get ariaDescribedBy() {
+    return this.showValidationError ? this.errorMessageId : null;
+  }
+
+  get ariaInvalid() {
+    return this.showValidationError ? "true" : "false";
+  }
+
+  get ariaRequired() {
+    return this.required ? "true" : "false";
+  }
+
+  get isLabelHidden() {
+    return this.variant === "label-hidden";
+  }
+
+  get computedLabelClass() {
+    return this.isLabelHidden
+      ? "slds-form-element__label slds-assistive-text"
+      : "slds-form-element__label";
+  }
+
+  get showDropdown() {
+    return this._open && !this.disabled;
+  }
+
+  get ariaExpanded() {
+    return this.showDropdown ? "true" : "false";
+  }
+
+  get comboboxClass() {
+    let cls = "slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click";
+    if (this.showDropdown) {
+      cls += " slds-is-open";
+    }
+    return cls;
+  }
+
+  get filteredOptions() {
+    let list = this._options;
+    if (this._dirty && this._searchTerm) {
+      const term = this._searchTerm.toLowerCase();
+      list = this._options.filter(
+        (opt) => opt && opt.label && opt.label.toLowerCase().includes(term),
+      );
+    }
+    return list.map((opt, index) => {
+      const selected = opt.value === this._value;
+      const active = index === this._activeIndex;
+      let optionClass =
+        "slds-media slds-listbox__option slds-listbox__option_plain slds-media_small";
+      if (selected) {
+        optionClass += " slds-is-selected";
+      }
+      if (active) {
+        optionClass += " slds-has-focus";
+      }
+      return {
+        label: opt.label,
+        value: opt.value,
+        key: String(opt.value),
+        selected,
+        optionClass,
+        ariaSelected: selected ? "true" : "false",
+      };
+    });
+  }
+
+  get hasNoMatches() {
+    return this.filteredOptions.length === 0;
+  }
+
+  get noMatchesLabel() {
+    return this.t("noMatchingResults");
+  }
+
+  // --- Event handlers -------------------------------------------------------
+
+  handleFocus(event) {
+    if (this.disabled) {
+      return;
+    }
+    this.cancelBlurTimer();
+    this._open = true;
+    this._dirty = false;
+    this._activeIndex = -1;
+    // Select all so the first keystroke replaces the displayed label.
+    const input = event.target;
+    requestAnimationFrame(() => {
+      try {
+        input.select();
+      } catch (e) {
+        // ignore - input may have been removed from the DOM
+      }
+    });
+  }
+
+  handleClick() {
+    if (this.disabled) {
+      return;
+    }
+    // Reopen when the input is already focused but the dropdown was closed.
+    if (!this._open) {
+      this._open = true;
+      this._dirty = false;
+      this._activeIndex = -1;
+    }
+  }
+
+  handleInput(event) {
+    this._searchTerm = event.target.value;
+    this._dirty = true;
+    this._open = true;
+    this.highlightFirstFilteredOption();
+  }
+
+  handleBlur() {
+    // Delay closing so a click on an option can register before we reset.
+    this.cancelBlurTimer();
+    this._blurTimer = setTimeout(() => {
+      this.closeAndReset();
+      this._blurTimer = null;
+    }, 200);
+  }
+
+  handleOptionMouseDown(event) {
+    // Prevent the input from losing focus (which would trigger blur/close
+    // before the click is processed).
+    event.preventDefault();
+    const value = event.currentTarget.dataset.value;
+    this.selectByDatasetValue(value);
+  }
+
+  handleKeydown(event) {
+    const key = event.key;
+    if (key === "ArrowDown") {
+      event.preventDefault();
+      if (!this._open) {
+        this._open = true;
+        this._dirty = false;
+      }
+      this.moveActive(1);
+    } else if (key === "ArrowUp") {
+      event.preventDefault();
+      this.moveActive(-1);
+    } else if (key === "Enter") {
+      const opts = this.filteredOptions;
+      const chosen =
+        opts[this._activeIndex] ||
+        (this._dirty && this._searchTerm ? opts[0] : null);
+      if (this._open && chosen) {
+        event.preventDefault();
+        this.commitSelection(chosen.value, chosen.label);
+      }
+    } else if (key === "Escape") {
+      if (this._open) {
+        event.preventDefault();
+        this.closeAndReset();
+      }
+    }
+  }
+
+  // --- Helpers --------------------------------------------------------------
+
+  moveActive(delta) {
+    const count = this.filteredOptions.length;
+    if (count === 0) {
+      this._activeIndex = -1;
+      return;
+    }
+    let next = this._activeIndex + delta;
+    if (next < 0) {
+      next = count - 1;
+    } else if (next >= count) {
+      next = 0;
+    }
+    this._activeIndex = next;
+  }
+
+  highlightFirstFilteredOption() {
+    const opts = this.filteredOptions;
+    this._activeIndex =
+      this._dirty && this._searchTerm && opts.length > 0 ? 0 : -1;
+  }
+
+  selectByDatasetValue(datasetValue) {
+    const found = this._options.find(
+      (opt) => opt && String(opt.value) === String(datasetValue),
+    );
+    const finalValue = found ? found.value : datasetValue;
+    const finalLabel = found ? found.label : "";
+    this.commitSelection(finalValue, finalLabel);
+  }
+
+  commitSelection(value, label) {
+    this._value = value;
+    this._searchTerm = label;
+    this._open = false;
+    this._dirty = false;
+    this._activeIndex = -1;
+    this.refreshVisibleValidity();
+    this.dispatchEvent(new CustomEvent("change", { detail: { value } }));
+  }
+
+  closeAndReset() {
+    this._open = false;
+    this._dirty = false;
+    this._activeIndex = -1;
+    // Restore the input text to reflect the currently selected option.
+    this._searchTerm = this.labelForValue(this._value);
+    this.refreshVisibleValidity();
+  }
+
+  @api
+  checkValidity() {
+    const message = this.getValidationMessage();
+    this.applyInputValidity(message);
+    const input = this.inputElement;
+    return input && typeof input.checkValidity === "function"
+      ? input.checkValidity()
+      : !message;
+  }
+
+  @api
+  reportValidity() {
+    const message = this.getValidationMessage();
+    this._validationMessage = message;
+    this._showValidationError = !!message;
+    this.applyInputValidity(message);
+    const input = this.inputElement;
+    return input && typeof input.reportValidity === "function"
+      ? input.reportValidity()
+      : !message;
+  }
+
+  @api
+  setCustomValidity(message) {
+    this._customValidityMessage = message || "";
+    const validationMessage = this.getValidationMessage();
+    this.applyInputValidity(validationMessage);
+    if (this._showValidationError) {
+      this._validationMessage = validationMessage;
+      this._showValidationError = !!validationMessage;
+    }
+  }
+
+  get inputElement() {
+    return this.template.querySelector("input");
+  }
+
+  hasSelectedValue() {
+    return (
+      this._value !== null && this._value !== undefined && this._value !== ""
+    );
+  }
+
+  getValidationMessage() {
+    if (this._customValidityMessage) {
+      return this._customValidityMessage;
+    }
+    return this.required && !this.hasSelectedValue()
+      ? this.t("requiredField")
+      : "";
+  }
+
+  applyInputValidity(message) {
+    const input = this.inputElement;
+    if (input && typeof input.setCustomValidity === "function") {
+      input.setCustomValidity(message);
+    }
+  }
+
+  refreshVisibleValidity() {
+    if (!this._showValidationError) {
+      return;
+    }
+    const message = this.getValidationMessage();
+    this._validationMessage = message;
+    this._showValidationError = !!message;
+    this.applyInputValidity(message);
+  }
+
+  cancelBlurTimer() {
+    if (this._blurTimer) {
+      clearTimeout(this._blurTimer);
+      this._blurTimer = null;
+    }
+  }
+
+  disconnectedCallback() {
+    this.cancelBlurTimer();
+    if (super.disconnectedCallback) {
+      super.disconnectedCallback();
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces a reusable **typeahead combobox** LWC component and wires it into the Metadata Retriever, plus two small fixes to how orgs are listed and labelled in the org selector.

### New `s-typeahead` component
The metadata type dropdown can be long; typeahead filtering makes it much faster to find a type. 
- Added a reusable `s/typeahead` Lightning Web Component (`.js`, `.html`, `.css`) that behaves like `lightning-combobox` but lets the user **type to filter** the available options.
- API-compatible with the subset of `lightning-combobox` used across the extension: `label`, `value`, `options`, `placeholder`, `required`, `disabled`, `variant` (`label-hidden`), and a `change` event whose detail carries the selected `value`.
- Includes keyboard navigation (highlighted active option) and validity handling.
- Replaced the Metadata Type `lightning-combobox` in the Metadata Retriever with `s-typeahead`, so users can filter the metadata type list by typing instead of scrolling a long dropdown.

### Org selector improvements (fixes #315)
The org selector changes avoid losing distinct users for the same org and surface friendly aliases first.
- **Allow multiple users for the same org**: dedupe the org list by `username` first (falling back to `orgId` / `instanceUrl`) instead of `orgId` first, so distinct users authenticated against the same org are no longer collapsed into one entry.
- **Prefer alias in org labels**: when formatting an org label, use the org `alias` before falling back to the (cleaned-up) `instanceUrl`, then `username` — making the org selector less confusing when aliases are set.
