### PR TITLE
feat: Add option to open file's containing folder from command results

### DIFF
--- a/.megalinter_github_conf/branch_protection_rules.json
+++ b/.megalinter_github_conf/branch_protection_rules.json
@@ -1,0 +1,5 @@
+{
+    "message": "Not Found",
+    "documentation_url": "https://docs.github.com/rest",
+    "status": "404"
+}

--- a/.megalinter_github_conf/branch_protection_rules.json
+++ b/.megalinter_github_conf/branch_protection_rules.json
@@ -1,5 +1,0 @@
-{
-    "message": "Not Found",
-    "documentation_url": "https://docs.github.com/rest",
-    "status": "404"
-}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,16 @@
 
 ## Unreleased
 
-- Command results: file buttons now let you open the file's containing folder, opening your system file explorer with the file already selected
-  - When a result offers both CSV and Excel versions, the Excel file's folder is opened
-  - Each option in the file button menu now shows an icon, and the menu stays fully visible instead of being cut off at the bottom of the panel
-- Metadata Retriever: new **Full metadata** toggle to retrieve complete components such as Profiles and Workflows without anything being truncated
-  - Slower than the standard retrieval, so it stays off by default
-  - A notice reminds you that most components retrieved this way can still be deployed with the standard Metadata API, though a few are not supported by Salesforce
-- Command results that show two tables in the same section (for example a success table followed by a failure table) now display both tables correctly, instead of repeating the last one twice
+- Command results
+  - File buttons now let you open the file's containing folder, opening your system file explorer with the file already selected
+    - When a result offers both CSV and Excel versions, the Excel file's folder is opened
+    - Each option in the file button menu now shows an icon, and the menu stays fully visible instead of being cut off at the bottom of the panel
+  - The button that opens the command log file now shows its icon, which was previously invisible
+  - Sections that show two tables (for example a success table followed by a failure table) now display both tables correctly, instead of repeating the last one twice
+- Metadata Retriever
+  - New **Full metadata** toggle to retrieve complete components such as Profiles and Workflows without anything being truncated
+    - Slower than the standard retrieval, so it stays off by default
+    - A notice reminds you that most components retrieved this way can still be deployed with the standard Metadata API, though a few are not supported by Salesforce
 
 ## [7.13.0] 2026-06-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Command results: file buttons now offer an option to open the file's containing folder in the file explorer
 - Metadata Retriever: new **Full metadata** toggle to retrieve complete components such as Profiles and Workflows without anything being truncated
   - Slower than the standard retrieval, so it stays off by default
   - A notice reminds you that most components retrieved this way can still be deployed with the standard Metadata API, though a few are not supported by Salesforce

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-- Command results: file buttons now offer an option to open the file's containing folder in the file explorer
+- Command results: file buttons now let you open the file's containing folder, opening your system file explorer with the file already selected
+  - When a result offers both CSV and Excel versions, the Excel file's folder is opened
+  - Each option in the file button menu now shows an icon, and the menu stays fully visible instead of being cut off at the bottom of the panel
 - Metadata Retriever: new **Full metadata** toggle to retrieve complete components such as Profiles and Workflows without anything being truncated
   - Slower than the standard retrieval, so it stays off by default
   - A notice reminds you that most components retrieved this way can still be deployed with the standard Metadata API, though a few are not supported by Salesforce

--- a/src/commands/showMetadataRetriever.ts
+++ b/src/commands/showMetadataRetriever.ts
@@ -434,7 +434,11 @@ function getCrudReadOutcomePayload(result: any): any | null {
   return null;
 }
 
-function toRetrieveFile(item: any, state: "Changed" | "Failed", error?: string) {
+function toRetrieveFile(
+  item: any,
+  state: "Changed" | "Failed",
+  error?: string,
+) {
   return {
     state,
     type: item?.type || item?.memberType || "",
@@ -470,7 +474,9 @@ function normalizeCrudReadResult(result: any): any | null {
     ...skipped.map((item) => toRetrieveFile(item, "Failed", skippedProblem)),
   ];
   const messages = [
-    ...failures.map((item) => toRetrieveMessage(item, "CRUD Metadata API read failed")),
+    ...failures.map((item) =>
+      toRetrieveMessage(item, "CRUD Metadata API read failed"),
+    ),
     ...skipped.map((item) => toRetrieveMessage(item, skippedProblem)),
   ];
 
@@ -562,8 +568,7 @@ async function executeMetadataRetrieve(
           return await execSfdxJson(command, { cwd: workspaceRoot });
         },
       );
-    }
-    else {
+    } else {
       result = {
         status: 0,
         result: { success: true, files: [], messages: [] },
@@ -671,14 +676,12 @@ async function executeMetadataRetrieve(
         !!result.errorMessage;
       if (normalizedCrudResult) {
         result.result = normalizedCrudResult;
-      }
-      else if (crudFailed) {
+      } else if (crudFailed) {
         // Force the shared error branch to surface the CLI error message.
         if (result) {
           result.result = null;
         }
-      }
-      else {
+      } else {
         // Backward-compatible fallback for older command output that does not
         // expose successes/failures/skipped yet.
         const retrievedFiles = expandedList
@@ -748,8 +751,7 @@ async function executeMetadataRetrieve(
     if (!hasItemsToRetrieve) {
       // Only deleted items were processed (handled above) — there is no
       // retrieve/read outcome to report here.
-    }
-    else if (result && result.result) {
+    } else if (result && result.result) {
       const retrieveResult = result.result;
       const success = retrieveResult.success === true;
       const files = retrieveResult.files || [];
@@ -1896,8 +1898,14 @@ async function handleOpenRetrieveFolder() {
 
 async function handleRetrieveMetadata(panel: any, data: any) {
   try {
-    const { username, memberType, memberName, deleted, localPackage, useCrudApi } =
-      data;
+    const {
+      username,
+      memberType,
+      memberName,
+      deleted,
+      localPackage,
+      useCrudApi,
+    } = data;
 
     if (!username || !memberType || !memberName) {
       vscode.window.showErrorMessage(

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -1260,6 +1260,7 @@
   "openCommandLogFile": "Befehlsprotokolldatei öffnen",
   "openExportJson": "export.json öffnen",
   "openExportJsonInVsCode": "export.json in VS Code öffnen",
+  "openFile": "Datei öffnen",
   "openFolderInExplorer": "Ordner im Explorer öffnen",
   "openGit": "Git öffnen",
   "openLabel": "Öffnen",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1260,6 +1260,7 @@
   "openCommandLogFile": "Open command log file",
   "openExportJson": "Open export.json",
   "openExportJsonInVsCode": "Open export.json in VS Code",
+  "openFile": "Open file",
   "openFolderInExplorer": "Open folder in explorer",
   "openGit": "Open Git",
   "openLabel": "Open",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1260,6 +1260,7 @@
   "openCommandLogFile": "Abrir el archivo de registro del comando",
   "openExportJson": "Abrir export.json",
   "openExportJsonInVsCode": "Abrir export.json en VSCode",
+  "openFile": "Abrir archivo",
   "openFolderInExplorer": "Abrir carpeta en el explorador",
   "openGit": "Abrir Git",
   "openLabel": "Abrir",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -1260,6 +1260,7 @@
   "openCommandLogFile": "Ouvrir le fichier journal de la commande",
   "openExportJson": "Ouvrir export.json",
   "openExportJsonInVsCode": "Ouvrir export.json dans VS Code",
+  "openFile": "Ouvrir le fichier",
   "openFolderInExplorer": "Ouvrir le dossier dans l'explorateur",
   "openGit": "Ouvrir Git",
   "openLabel": "Ouvrir",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -1247,6 +1247,7 @@
   "openCommandLogFile": "Apri il file di log del comando",
   "openExportJson": "Apri export.json",
   "openExportJsonInVsCode": "Apri export.json in VS Code",
+  "openFile": "Apri file",
   "openFolderInExplorer": "Apri cartella in Esplora risorse",
   "openGit": "Apri Git",
   "openLabel": "Apri",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -1260,6 +1260,7 @@
   "openCommandLogFile": "コマンドログファイルを開く",
   "openExportJson": "export.json を開く",
   "openExportJsonInVsCode": "VS Code で export.json を開く",
+  "openFile": "ファイルを開く",
   "openFolderInExplorer": "エクスプローラーでフォルダーを開く",
   "openGit": "Git を開く",
   "openLabel": "開く",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -1260,6 +1260,7 @@
   "openCommandLogFile": "Opdrachtlogboekbestand openen",
   "openExportJson": "export.json openen",
   "openExportJsonInVsCode": "export.json openen in VS Code",
+  "openFile": "Bestand openen",
   "openFolderInExplorer": "Map openen in verkenner",
   "openGit": "Git openen",
   "openLabel": "Openen",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -1254,6 +1254,7 @@
   "openCommandLogFile": "Otwórz plik logów polecenia",
   "openExportJson": "Otwórz export.json",
   "openExportJsonInVsCode": "Otwórz export.json w VS Code",
+  "openFile": "Otwórz plik",
   "openFolderInExplorer": "Otwórz folder w eksploratorze",
   "openGit": "Otwórz Git",
   "openLabel": "Otwórz",

--- a/src/i18n/pt-BR.json
+++ b/src/i18n/pt-BR.json
@@ -1256,6 +1256,7 @@
   "openCommandLogFile": "Abrir arquivo de log do comando",
   "openExportJson": "Abrir export.json",
   "openExportJsonInVsCode": "Abrir export.json no VS Code",
+  "openFile": "Abrir arquivo",
   "openFolderInExplorer": "Abrir pasta no explorador",
   "openGit": "Abrir Git",
   "openLabel": "Abrir",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1000,12 +1000,15 @@ export async function promptToDisableTlsIfNeeded(
 
 export function openFolderInExplorer(folderPath: string) {
   const platform = process.platform;
+  // Normalize to platform-specific separators: Windows Explorer only accepts
+  // backslashes and silently falls back to the Documents folder otherwise.
+  const normalizedPath = path.normalize(folderPath);
   if (platform === "win32") {
-    childProcess.exec(`explorer "${folderPath}"`);
+    childProcess.exec(`explorer "${normalizedPath}"`);
   } else if (platform === "darwin") {
-    childProcess.exec(`open "${folderPath}"`);
+    childProcess.exec(`open "${normalizedPath}"`);
   } else if (platform === "linux") {
-    childProcess.exec(`xdg-open "${folderPath}"`);
+    childProcess.exec(`xdg-open "${normalizedPath}"`);
   } else {
     vscode.window.showErrorMessage(`Unsupported platform ${platform}`);
   }

--- a/src/webviews/lwc-ui-panel.ts
+++ b/src/webviews/lwc-ui-panel.ts
@@ -4,6 +4,7 @@ import {
   execCommandWithProgress,
   execSfdxJsonWithProgress,
   isWebVsCode,
+  openFolderInExplorer,
 } from "../utils";
 import { Logger } from "../logger";
 import { getAllTranslations, getCurrentLocale, t } from "../i18n/i18n";
@@ -298,6 +299,9 @@ export class LwcUiPanel {
           break;
         case "openFolder":
           await this.handleFolderOpen(data.folderPath);
+          break;
+        case "openFolderInFileManager":
+          await this.handleOpenFolderInFileManager(data.folderPath);
           break;
         case "openExternal":
           await this.handleOpenExternal(data.url || data);
@@ -618,6 +622,31 @@ export class LwcUiPanel {
       Logger.log(`Revealed folder in explorer: ${resolvedPath}`);
     } catch (error) {
       Logger.log("Error revealing folder:\n" + JSON.stringify(error));
+      vscode.window.showErrorMessage(t("failedToOpenFolder", { error }));
+    }
+  }
+
+  /**
+   * Handle request to open a folder in the OS file manager (Explorer/Finder)
+   * @param folderPathInit Path to the folder to open
+   */
+  private async handleOpenFolderInFileManager(
+    folderPathInit: string,
+  ): Promise<void> {
+    try {
+      const resolvedPath = this.resolveWorkspacePath(folderPathInit);
+      const folderUri = vscode.Uri.file(resolvedPath);
+      const stat = await vscode.workspace.fs.stat(folderUri);
+      if (!(stat.type & vscode.FileType.Directory)) {
+        vscode.window.showErrorMessage(
+          t("pathIsNotAFolder", { path: resolvedPath }),
+        );
+        return;
+      }
+      openFolderInExplorer(resolvedPath);
+      Logger.log(`Opened folder in file manager: ${resolvedPath}`);
+    } catch (error) {
+      Logger.log("Error opening folder in file manager:\n" + JSON.stringify(error));
       vscode.window.showErrorMessage(t("failedToOpenFolder", { error }));
     }
   }

--- a/src/webviews/lwc-ui-panel.ts
+++ b/src/webviews/lwc-ui-panel.ts
@@ -4,7 +4,6 @@ import {
   execCommandWithProgress,
   execSfdxJsonWithProgress,
   isWebVsCode,
-  openFolderInExplorer,
 } from "../utils";
 import { Logger } from "../logger";
 import { getAllTranslations, getCurrentLocale, t } from "../i18n/i18n";
@@ -301,7 +300,7 @@ export class LwcUiPanel {
           await this.handleFolderOpen(data.folderPath);
           break;
         case "openFolderInFileManager":
-          await this.handleOpenFolderInFileManager(data.folderPath);
+          await this.handleOpenFolderInFileManager(data.filePath);
           break;
         case "openExternal":
           await this.handleOpenExternal(data.url || data);
@@ -627,26 +626,25 @@ export class LwcUiPanel {
   }
 
   /**
-   * Handle request to open a folder in the OS file manager (Explorer/Finder)
-   * @param folderPathInit Path to the folder to open
+   * Handle request to reveal a file in the OS file manager (Explorer/Finder).
+   * Opens the file's parent folder and pre-selects the file, cross-platform.
+   * @param filePathInit Path to the file to reveal
    */
   private async handleOpenFolderInFileManager(
-    folderPathInit: string,
+    filePathInit: string,
   ): Promise<void> {
     try {
-      const resolvedPath = this.resolveWorkspacePath(folderPathInit);
-      const folderUri = vscode.Uri.file(resolvedPath);
-      const stat = await vscode.workspace.fs.stat(folderUri);
-      if (!(stat.type & vscode.FileType.Directory)) {
-        vscode.window.showErrorMessage(
-          t("pathIsNotAFolder", { path: resolvedPath }),
-        );
-        return;
-      }
-      openFolderInExplorer(resolvedPath);
-      Logger.log(`Opened folder in file manager: ${resolvedPath}`);
+      const resolvedPath = this.resolveWorkspacePath(filePathInit);
+      const fileUri = vscode.Uri.file(resolvedPath);
+      // Ensure the target exists before asking the OS to reveal it
+      await vscode.workspace.fs.stat(fileUri);
+      // revealFileInOS opens the OS file manager and selects the file
+      await vscode.commands.executeCommand("revealFileInOS", fileUri);
+      Logger.log(`Revealed file in OS file manager: ${resolvedPath}`);
     } catch (error) {
-      Logger.log("Error opening folder in file manager:\n" + JSON.stringify(error));
+      Logger.log(
+        "Error revealing file in file manager:\n" + JSON.stringify(error),
+      );
       vscode.window.showErrorMessage(t("failedToOpenFolder", { error }));
     }
   }

--- a/src/webviews/lwc-ui/modules/s/commandExecution/commandExecution.css
+++ b/src/webviews/lwc-ui/modules/s/commandExecution/commandExecution.css
@@ -194,9 +194,16 @@
 .report-format-dropdown .slds-dropdown__item a {
   padding: 0.5rem 0.75rem;
   text-decoration: none;
-  display: block;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start; /* Override SLDS space-between so label sits next to its icon */
+  text-align: left;
   font-size: 0.875rem;
   line-height: 1.25;
+}
+
+.report-format-dropdown .slds-dropdown__item a .report-dropdown-option-icon {
+  flex-shrink: 0;
 }
 
 .report-format-dropdown .slds-dropdown__item a:hover {

--- a/src/webviews/lwc-ui/modules/s/commandExecution/commandExecution.css
+++ b/src/webviews/lwc-ui/modules/s/commandExecution/commandExecution.css
@@ -150,20 +150,31 @@
 }
 
 /* Reset the dropdown itself, as it's now inside the positioned container */
-.report-format-dropdown {
+.report-dropdown-container .report-format-dropdown {
   min-width: 120px;
 
-  /* Default hidden state (in case wrapper is missing or was removed) */
+  /* Default: open below the button */
   position: absolute;
   left: 0;
+  top: 100%;
+  bottom: auto;
+  margin-top: 4px;
+  margin-bottom: 0;
   z-index: 9999;
   visibility: hidden;
   opacity: 0;
-  transform: translateY(8px);
+  transform: translateY(-8px);
   transition: all 0.12s ease-out;
   pointer-events: none;
+}
+
+/* Flip above the button when there is not enough room below */
+.report-dropdown-container.dropdown-above .report-format-dropdown {
+  top: auto;
   bottom: 100%;
+  margin-top: 0;
   margin-bottom: 4px;
+  transform: translateY(8px);
 }
 
 /* When the dropdown container receives slds-is-open, show the dropdown */

--- a/src/webviews/lwc-ui/modules/s/commandExecution/commandExecution.html
+++ b/src/webviews/lwc-ui/modules/s/commandExecution/commandExecution.html
@@ -532,12 +532,13 @@
                           <ul class="slds-dropdown__list" role="menu">
                             <template for:each={reportFile.dropdownOptions} for:item="option">
                               <li key={option.type} class="slds-dropdown__item" role="presentation">
-                                <a href="javascript:void(0);" role="menuitem" tabindex="-1" 
-                                   data-type={option.type} 
+                                <a href="javascript:void(0);" role="menuitem" tabindex="-1"
+                                   data-type={option.type}
                                    data-file-path={option.file}
                                    data-format={option.format}
                                    data-report-id={reportFile.id}
                                    onclick={handleReportFileDropdownSelect}>
+                                  <lightning-icon icon-name={option.iconName} size="x-small" class="slds-m-right_x-small report-dropdown-option-icon"></lightning-icon>
                                   <span class="slds-truncate" title={option.label}>{option.label}</span>
                                 </a>
                               </li>

--- a/src/webviews/lwc-ui/modules/s/commandExecution/commandExecution.html
+++ b/src/webviews/lwc-ui/modules/s/commandExecution/commandExecution.html
@@ -28,7 +28,7 @@
             <span class="slds-text-heading_small">{commandTitle}</span>
             <template if:true={commandLogFile}>
               <lightning-button-icon
-                icon-name="utility:log"
+                icon-name="utility:description"
                 variant="bare"
                 alternative-text={i18n.openCommandLogFile}
                 title={i18n.openCommandLogFile}

--- a/src/webviews/lwc-ui/modules/s/commandExecution/commandExecution.js
+++ b/src/webviews/lwc-ui/modules/s/commandExecution/commandExecution.js
@@ -1650,42 +1650,47 @@ ${resultMessage}`;
     const groupedReports = groupSimilarFiles(reports);
     const groupedDocUrls = groupSimilarFiles(docUrls);
 
+    // Shared "open containing folder in the OS explorer" dropdown option
+    const openFolderOption = (f) => ({
+      label: this.i18n.openFolderInExplorer,
+      type: f.type,
+      file: f.file,
+      format: "openFolder",
+      iconName: "utility:open_folder",
+    });
+
+    // Shared builder for the dropdown result shape (stable id + success button)
+    const buildDropdownResult = (f, idPrefix, dropdownOptions) => ({
+      ...f,
+      id: `${idPrefix}_${(f.id || f.file || "").replace(/[^a-zA-Z0-9]/g, "")}`,
+      buttonVariant: "success",
+      iconName: "utility:page",
+      iconVariant: "inverse",
+      isDropdown: true,
+      dropdownOptions,
+    });
+
     // Map to add button/icon props as before
     const decorate = (f) => {
       // Handle package.xml files with a dedicated two-option dropdown
       if (f.isPackageXml) {
-        const stableId = `packagexml_${(f.id || f.file || "").replace(/[^a-zA-Z0-9]/g, "")}`;
-        return {
-          ...f,
-          id: stableId,
-          buttonVariant: "success",
-          iconName: "utility:page",
-          iconVariant: "inverse",
-          isDropdown: true,
-          dropdownOptions: [
-            {
-              label: this.i18n.openWithPackageXmlViewer,
-              type: f.type,
-              file: f.file,
-              format: "packagexmlViewer",
-              iconName: "utility:page",
-            },
-            {
-              label: this.i18n.openWithVsCode,
-              type: f.type,
-              file: f.file,
-              format: "packagexmlVsCode",
-              iconName: "utility:open",
-            },
-            {
-              label: this.i18n.openFolderInExplorer,
-              type: f.type,
-              file: f.file,
-              format: "openFolder",
-              iconName: "utility:open_folder",
-            },
-          ],
-        };
+        return buildDropdownResult(f, "packagexml", [
+          {
+            label: this.i18n.openWithPackageXmlViewer,
+            type: f.type,
+            file: f.file,
+            format: "packagexmlViewer",
+            iconName: "utility:page",
+          },
+          {
+            label: this.i18n.openWithVsCode,
+            type: f.type,
+            file: f.file,
+            format: "packagexmlVsCode",
+            iconName: "utility:open",
+          },
+          openFolderOption(f),
+        ]);
       }
 
       // Handle standalone local report files with a dedicated two-option dropdown
@@ -1696,31 +1701,16 @@ ${resultMessage}`;
         !f.file.startsWith("http") &&
         !f.isDropdown
       ) {
-        const stableId = `report_${(f.id || f.file || "").replace(/[^a-zA-Z0-9]/g, "")}`;
-        return {
-          ...f,
-          id: stableId,
-          buttonVariant: "success",
-          iconName: "utility:page",
-          iconVariant: "inverse",
-          isDropdown: true,
-          dropdownOptions: [
-            {
-              label: this.i18n.openFile,
-              type: f.type,
-              file: f.file,
-              format: "openFileLocal",
-              iconName: "utility:open",
-            },
-            {
-              label: this.i18n.openFolderInExplorer,
-              type: f.type,
-              file: f.file,
-              format: "openFolder",
-              iconName: "utility:open_folder",
-            },
-          ],
-        };
+        return buildDropdownResult(f, "report", [
+          {
+            label: this.i18n.openFile,
+            type: f.type,
+            file: f.file,
+            format: "openFileLocal",
+            iconName: "utility:open",
+          },
+          openFolderOption(f),
+        ]);
       }
 
       const baseProps = {

--- a/src/webviews/lwc-ui/modules/s/commandExecution/commandExecution.js
+++ b/src/webviews/lwc-ui/modules/s/commandExecution/commandExecution.js
@@ -2241,8 +2241,23 @@ ${resultMessage}`;
     const isOpen = container.classList.contains("slds-is-open");
 
     if (!isOpen) {
+      // Open first so the dropdown gets laid out (its height is 0 while the
+      // SLDS trigger is closed), then measure to decide the direction.
       container.classList.add("slds-is-open");
       dropdown.classList.add("slds-is-open");
+
+      // Flip above the button when there is not enough room below it (the panel
+      // scroll area would otherwise clip the dropdown). Done synchronously in
+      // the same tick so the user never sees it open in the wrong direction.
+      const containerRect = container.getBoundingClientRect();
+      const dropdownHeight = dropdown.offsetHeight || 0;
+      const spaceBelow = window.innerHeight - containerRect.bottom;
+      const spaceAbove = containerRect.top;
+      if (spaceBelow < dropdownHeight + 8 && spaceAbove > spaceBelow) {
+        container.classList.add("dropdown-above");
+      } else {
+        container.classList.remove("dropdown-above");
+      }
 
       // Add document listener (use pre-bound reference)
       setTimeout(() => {

--- a/src/webviews/lwc-ui/modules/s/commandExecution/commandExecution.js
+++ b/src/webviews/lwc-ui/modules/s/commandExecution/commandExecution.js
@@ -1622,12 +1622,19 @@ ${resultMessage}`;
                 type: f.type,
                 file: f.file,
                 format: f.format,
+                iconName:
+                  f.format === "CSV"
+                    ? "doctype:csv"
+                    : f.format === "XLSX"
+                      ? "doctype:excel"
+                      : "utility:file",
               })),
               {
                 label: this.i18n.openFolderInExplorer,
                 type: folderRefFile.type,
                 file: folderRefFile.file,
                 format: "openFolder",
+                iconName: "utility:open_folder",
               },
             ],
           });
@@ -1661,18 +1668,21 @@ ${resultMessage}`;
               type: f.type,
               file: f.file,
               format: "packagexmlViewer",
+              iconName: "utility:page",
             },
             {
               label: this.i18n.openWithVsCode,
               type: f.type,
               file: f.file,
               format: "packagexmlVsCode",
+              iconName: "utility:open",
             },
             {
               label: this.i18n.openFolderInExplorer,
               type: f.type,
               file: f.file,
               format: "openFolder",
+              iconName: "utility:open_folder",
             },
           ],
         };
@@ -1700,12 +1710,14 @@ ${resultMessage}`;
               type: f.type,
               file: f.file,
               format: "openFileLocal",
+              iconName: "utility:open",
             },
             {
               label: this.i18n.openFolderInExplorer,
               type: f.type,
               file: f.file,
               format: "openFolder",
+              iconName: "utility:open_folder",
             },
           ],
         };

--- a/src/webviews/lwc-ui/modules/s/commandExecution/commandExecution.js
+++ b/src/webviews/lwc-ui/modules/s/commandExecution/commandExecution.js
@@ -1601,6 +1601,10 @@ ${resultMessage}`;
           // Multiple formats, create dropdown
           // Use a stable ID based on the title to prevent issues on re-render
           const stableId = `dropdown_${baseTitle.replace(/[^a-zA-Z0-9]/g, "")}`;
+          // Prefer the Excel file for the "open folder" option so its folder is
+          // revealed (and the Excel file selected); fall back to the first file.
+          const folderRefFile =
+            group.files.find((f) => f.format === "XLSX") || group.files[0];
           result.push({
             id: stableId,
             title: baseTitle,
@@ -1621,8 +1625,8 @@ ${resultMessage}`;
               })),
               {
                 label: this.i18n.openFolderInExplorer,
-                type: group.files[0].type,
-                file: group.files[0].file,
+                type: folderRefFile.type,
+                file: folderRefFile.file,
                 format: "openFolder",
               },
             ],
@@ -2315,14 +2319,11 @@ ${resultMessage}`;
       return;
     }
     if (format === "openFolder") {
-      const idx = Math.max(
-        filePath.lastIndexOf("/"),
-        filePath.lastIndexOf("\\"),
-      );
-      const folderPath = idx > 0 ? filePath.substring(0, idx) : filePath;
+      // Reveal the file in the OS file manager; VS Code opens its parent folder
+      // and pre-selects the file.
       window.sendMessageToVSCode({
         type: "openFolderInFileManager",
-        data: { folderPath },
+        data: { filePath },
       });
       return;
     }

--- a/src/webviews/lwc-ui/modules/s/commandExecution/commandExecution.js
+++ b/src/webviews/lwc-ui/modules/s/commandExecution/commandExecution.js
@@ -1606,18 +1606,26 @@ ${resultMessage}`;
             title: baseTitle,
             type: group.files[0].type, // Use the type from the first file
             isDropdown: true,
-            dropdownOptions: group.files.map((f) => ({
-              label:
-                f.format === "CSV"
-                  ? "CSV"
-                  : f.format === "XLSX"
-                    ? "Excel"
-                    : f.format,
-              value: f.file, // Keep value for compatibility if needed elsewhere
-              type: f.type,
-              file: f.file,
-              format: f.format,
-            })),
+            dropdownOptions: [
+              ...group.files.map((f) => ({
+                label:
+                  f.format === "CSV"
+                    ? "CSV"
+                    : f.format === "XLSX"
+                      ? "Excel"
+                      : f.format,
+                value: f.file, // Keep value for compatibility if needed elsewhere
+                type: f.type,
+                file: f.file,
+                format: f.format,
+              })),
+              {
+                label: this.i18n.openFolderInExplorer,
+                type: group.files[0].type,
+                file: group.files[0].file,
+                format: "openFolder",
+              },
+            ],
           });
         }
       }
@@ -1655,6 +1663,45 @@ ${resultMessage}`;
               type: f.type,
               file: f.file,
               format: "packagexmlVsCode",
+            },
+            {
+              label: this.i18n.openFolderInExplorer,
+              type: f.type,
+              file: f.file,
+              format: "openFolder",
+            },
+          ],
+        };
+      }
+
+      // Handle standalone local report files with a dedicated two-option dropdown
+      // (open file / open containing folder)
+      if (
+        f.type === "report" &&
+        f.file &&
+        !f.file.startsWith("http") &&
+        !f.isDropdown
+      ) {
+        const stableId = `report_${(f.id || f.file || "").replace(/[^a-zA-Z0-9]/g, "")}`;
+        return {
+          ...f,
+          id: stableId,
+          buttonVariant: "success",
+          iconName: "utility:page",
+          iconVariant: "inverse",
+          isDropdown: true,
+          dropdownOptions: [
+            {
+              label: this.i18n.openFile,
+              type: f.type,
+              file: f.file,
+              format: "openFileLocal",
+            },
+            {
+              label: this.i18n.openFolderInExplorer,
+              type: f.type,
+              file: f.file,
+              format: "openFolder",
             },
           ],
         };
@@ -2264,6 +2311,18 @@ ${resultMessage}`;
       window.sendMessageToVSCode({
         type: "openFile",
         data: { filePath },
+      });
+      return;
+    }
+    if (format === "openFolder") {
+      const idx = Math.max(
+        filePath.lastIndexOf("/"),
+        filePath.lastIndexOf("\\"),
+      );
+      const folderPath = idx > 0 ? filePath.substring(0, idx) : filePath;
+      window.sendMessageToVSCode({
+        type: "openFolderInFileManager",
+        data: { folderPath },
       });
       return;
     }


### PR DESCRIPTION
## Overview

Adds the ability to open a report file's **containing folder** directly from the file buttons shown at the bottom of the command results panel. The folder opens in your system file explorer (Windows Explorer / Finder / Linux file manager) with the file already **selected**.

## What's new

- **Open folder option** on command-result file buttons
  - File buttons are now split-button dropdowns; the dropdown offers *Open file* and *Open folder in explorer*
  - Selecting *Open folder in explorer* reveals the file in the OS file explorer with it pre-selected (via VS Code's `revealFileInOS`)
  - When a result offers both **CSV and Excel** versions, the folder of the **Excel** file is revealed
  - Also available on the `package.xml` button menu
- **Icons** in the dropdown menu
  - Each option shows an SLDS icon (`doctype:csv`, `doctype:excel`, `utility:open`, `utility:open_folder`, `utility:page`), left-aligned next to its label
- **Smart dropdown positioning**
  - The menu now opens upward when there isn't enough room below the button, so it is no longer cut off at the bottom of the panel

## Implementation notes

- New `openFolderInFileManager` message type handled in `lwc-ui-panel.ts` → `revealFileInOS` on the resolved file URI
- `openFolderInExplorer()` in `utils.ts` now normalizes the path (`path.normalize`) so Windows Explorer receives back-slashes instead of silently falling back to the Documents folder
- Dropdown direction is decided in `handleReportDropdownToggle` by measuring available space (the SLDS trigger has zero height while closed, so measurement happens after opening, within the same tick to avoid a flash)

## i18n

- Added `openFile` key to all 9 locale files; reused the existing `openFolderInExplorer` key

## Verification

- `yarn lint`, `yarn compile`, and full `yarn dev` webpack build all pass (only the pre-existing unrelated `isCSR` warning)
- Manually verified in the Extension Development Host: folder opens with the file selected, Excel file targeted for CSV/Excel groups, menu flips upward near the panel bottom, icons render left-aligned

🤖 Generated with [Claude Code](https://claude.com/claude-code)
