### PR TITLE
Integrates `sf hardis:doctor` and refines Help menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Help menu
+  - The **Post an issue on GitHub** entry now runs `sf hardis:doctor`, which collects diagnostics to help you open a well-formed issue, and falls back to opening the GitHub issues page in your browser when sfdx-hardis is not installed
+  - Renamed the **Contact us to get help** entry to **Get assistance from Cloudity**
+
 ## [7.14.0] 2026-07-06
 
 - Metadata Retriever

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -331,7 +331,7 @@ export class Commands {
       async () => {
         const issuesUrl =
           "https://github.com/hardisgroupcom/sfdx-hardis/issues";
-        let isSfdxHardisInstalled = false;
+        let isSfdxHardisInstalled: boolean;
         try {
           const sfPluginsResult = await execCommand("sf plugins", {
             output: true,

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -4,7 +4,7 @@ import { HardisCommandsProvider } from "./hardis-commands-provider";
 import { HardisStatusProvider } from "./hardis-status-provider";
 import { HardisPluginsProvider } from "./hardis-plugins-provider";
 import { LocalWebSocketServer } from "./hardis-websocket-server";
-import { openFolderInExplorer, resetCache } from "./utils";
+import { execCommand, openFolderInExplorer, resetCache } from "./utils";
 import TelemetryReporter from "@vscode/extension-telemetry";
 import { CommandRunner } from "./command-runner";
 import { runSalesforceCliMcpServer } from "./utils/mcpUtils";
@@ -75,6 +75,7 @@ export class Commands {
     this.registerOpenPluginHelp();
     this.registerShowMessage();
     this.registerSelectExtensionTheme();
+    this.registerPostIssueOnGithub();
     this.registerSimulateDeployment();
     this.registerGeneratePackageXmlDoc();
     this.registerGenerateFlowDocumentation();
@@ -314,6 +315,47 @@ export class Commands {
       "vscode-sfdx-hardis.selectExtensionTheme",
       async () => {
         await ThemeUtils.promptUpdateConfiguration();
+      },
+    );
+    this.disposables.push(disposable);
+  }
+
+  registerPostIssueOnGithub() {
+    // "Post an issue on GitHub" menu entry.
+    // Prefer running "sf hardis:doctor", which collects diagnostics and guides
+    // the user to open a well-formed GitHub issue. When the sfdx-hardis plugin
+    // is not installed (so the command cannot run), fall back to opening the
+    // GitHub issues page directly in the browser.
+    const disposable = vscode.commands.registerCommand(
+      "vscode-sfdx-hardis.postIssueOnGithub",
+      async () => {
+        const issuesUrl =
+          "https://github.com/hardisgroupcom/sfdx-hardis/issues";
+        let isSfdxHardisInstalled = false;
+        try {
+          const sfPluginsResult = await execCommand("sf plugins", {
+            output: true,
+            fail: false,
+            cacheSection: "app",
+            cacheExpiration: 1000 * 60 * 60 * 24, // 1 day
+          });
+          isSfdxHardisInstalled = (sfPluginsResult?.stdout || "").includes(
+            "sfdx-hardis",
+          );
+        } catch {
+          isSfdxHardisInstalled = false;
+        }
+        if (isSfdxHardisInstalled) {
+          vscode.commands.executeCommand(
+            "vscode-sfdx-hardis.execute-command",
+            "sf hardis:doctor",
+          );
+        } else {
+          vscode.commands.executeCommand(
+            "vscode-sfdx-hardis.openExternal",
+            vscode.Uri.parse(issuesUrl),
+          );
+        }
       },
     );
     this.disposables.push(disposable);

--- a/src/hardis-commands-provider.ts
+++ b/src/hardis-commands-provider.ts
@@ -1119,9 +1119,7 @@ export class HardisCommandsProvider implements vscode.TreeDataProvider<CommandTr
           {
             id: "question",
             label: t("postIssueOnGithub"),
-            command: `vscode-sfdx-hardis.openExternal ${vscode.Uri.parse(
-              "https://github.com/hardisgroupcom/sfdx-hardis/issues",
-            )}`,
+            command: "vscode-sfdx-hardis.postIssueOnGithub",
           },
           {
             id: "hardis",

--- a/src/hardis-websocket-server.ts
+++ b/src/hardis-websocket-server.ts
@@ -212,6 +212,7 @@ export class LocalWebSocketServer {
             message: data.message,
             timestamp: new Date(),
             isQuestion: data.isQuestion || false,
+            alwaysVisible: data.alwaysVisible || false,
           },
         });
       }
@@ -423,6 +424,18 @@ export class LocalWebSocketServer {
             vscode.commands.executeCommand("markdown.showPreview", doc);
           });
         }
+      });
+    }
+    // Request the extension version (used by "sf hardis:doctor").
+    // Answered regardless of userInput mode, as the command can run outside the LWC UI.
+    else if (data.event === "getExtensionVersion") {
+      const ext = vscode.extensions.getExtension(
+        "NicolasVuillamy.vscode-sfdx-hardis",
+      );
+      const extensionVersion = ext?.packageJSON?.version ?? "unknown";
+      this.sendResponse(ws, {
+        event: "extensionVersionResponse",
+        extensionVersion,
       });
     }
     // Request user input

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -245,7 +245,7 @@
   "connectedTo": "Verbunden mit {{platform}}",
   "connectedToProviderAction": "Sie sind mit {{providerName}} verbunden. Was möchten Sie tun?",
   "contactUs": "Kontaktieren Sie uns",
-  "contactUsForHelp": "Kontaktieren Sie uns für Hilfe 🤗",
+  "contactUsForHelp": "Unterstützung von Cloudity erhalten 🤗",
   "copiedLabel": "Kopiert!",
   "copiedToClipboard": "In die Zwischenablage kopiert.",
   "copyFromBranch": "Von Branch kopieren",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -245,7 +245,7 @@
   "connectedTo": "Connected to {{platform}}",
   "connectedToProviderAction": "You are connected to {{providerName}}. What would you like to do?",
   "contactUs": "Contact Us",
-  "contactUsForHelp": "Contact us to get help 🤗",
+  "contactUsForHelp": "Get assistance from Cloudity 🤗",
   "copiedLabel": "Copied!",
   "copiedToClipboard": "Copied to clipboard.",
   "copyFromBranch": "Copy from branch",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -245,7 +245,7 @@
   "connectedTo": "Conectado a {{platform}}",
   "connectedToProviderAction": "Está conectado a {{providerName}}. ¿Qué desea hacer?",
   "contactUs": "Contáctenos",
-  "contactUsForHelp": "Contáctenos para obtener ayuda 🤗",
+  "contactUsForHelp": "Obtenga asistencia de Cloudity 🤗",
   "copiedLabel": "¡Copiado!",
   "copiedToClipboard": "Copiado al portapapeles.",
   "copyFromBranch": "Copiar desde una rama",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -245,7 +245,7 @@
   "connectedTo": "Connecté à {{platform}}",
   "connectedToProviderAction": "Vous êtes connecté à {{providerName}}. Que souhaitez-vous faire ?",
   "contactUs": "Contactez-nous",
-  "contactUsForHelp": "Contactez-nous pour obtenir de l'aide 🤗",
+  "contactUsForHelp": "Obtenez de l'aide de Cloudity 🤗",
   "copiedLabel": "Copié !",
   "copiedToClipboard": "Copié dans le presse-papiers.",
   "copyFromBranch": "Copier depuis une branche",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -241,7 +241,7 @@
   "connectedTo": "Connesso a {{platform}}",
   "connectedToProviderAction": "Sei connesso a {{providerName}}. Cosa vuoi fare?",
   "contactUs": "Contattaci",
-  "contactUsForHelp": "Contattaci per ricevere assistenza 🤗",
+  "contactUsForHelp": "Ottieni assistenza da Cloudity 🤗",
   "copiedLabel": "Copiato!",
   "copiedToClipboard": "Copiato negli appunti.",
   "copyFromBranch": "Copia da branch",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -245,7 +245,7 @@
   "connectedTo": "{{platform}} に接続済み",
   "connectedToProviderAction": "{{providerName}} に接続済みです。何を行いますか？",
   "contactUs": "お問い合わせ",
-  "contactUsForHelp": "サポートが必要な場合はお問い合わせください 🤗",
+  "contactUsForHelp": "Cloudity のサポートを受ける 🤗",
   "copiedLabel": "コピーしました！",
   "copiedToClipboard": "クリップボードにコピーしました。",
   "copyFromBranch": "別のブランチからコピー",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -245,7 +245,7 @@
   "connectedTo": "Verbonden met {{platform}}",
   "connectedToProviderAction": "Je bent verbonden met {{providerName}}. Wat wil je doen?",
   "contactUs": "Neem contact op",
-  "contactUsForHelp": "Neem contact met ons op voor hulp 🤗",
+  "contactUsForHelp": "Krijg hulp van Cloudity 🤗",
   "copiedLabel": "Gekopieerd!",
   "copiedToClipboard": "Gekopieerd naar klembord.",
   "copyFromBranch": "Kopiëren van branch",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -244,7 +244,7 @@
   "connectedTo": "Połączono z {{platform}}",
   "connectedToProviderAction": "Jesteś połączony z {{providerName}}. Co chcesz zrobić?",
   "contactUs": "Skontaktuj się z nami",
-  "contactUsForHelp": "Skontaktuj się z nami, aby uzyskać pomoc 🤗",
+  "contactUsForHelp": "Uzyskaj pomoc od Cloudity 🤗",
   "copiedLabel": "Skopiowano!",
   "copiedToClipboard": "Skopiowano do schowka.",
   "copyFromBranch": "Kopiuj z gałęzi",

--- a/src/i18n/pt-BR.json
+++ b/src/i18n/pt-BR.json
@@ -245,7 +245,7 @@
   "connectedTo": "Conectado a {{platform}}",
   "connectedToProviderAction": "Você está conectado a {{providerName}}. O que deseja fazer?",
   "contactUs": "Entre em Contato",
-  "contactUsForHelp": "Entre em contato conosco para obter ajuda 🤗",
+  "contactUsForHelp": "Obtenha assistência da Cloudity 🤗",
   "copiedLabel": "Copiado!",
   "copiedToClipboard": "Copiado para a área de transferência.",
   "copyFromBranch": "Copiar de outro branch",

--- a/src/webviews/lwc-ui/modules/s/commandExecution/commandExecution.js
+++ b/src/webviews/lwc-ui/modules/s/commandExecution/commandExecution.js
@@ -682,6 +682,7 @@ export default class CommandExecution extends SharedMixin(LightningElement) {
       isQuestion: logData.isQuestion || false,
       isAnswer: this.isWaitingForAnswer,
       isQuery: logData.isQuery || false,
+      alwaysVisible: logData.alwaysVisible || false,
     };
 
     // Detect if this is a sub-command and determine its running state
@@ -847,6 +848,8 @@ export default class CommandExecution extends SharedMixin(LightningElement) {
       hasError: false,
       isQuestion: actionLog.isQuestion || false,
       hasCopyTokens: this.containsCopyMarkup(actionLog.message),
+      // An action flagged alwaysVisible keeps its own section expanded even when new sections open
+      alwaysVisible: actionLog.alwaysVisible === true,
     };
 
     // Collapse the previous section if it's not a question
@@ -856,6 +859,7 @@ export default class CommandExecution extends SharedMixin(LightningElement) {
         previousSection &&
         !previousSection.isQuestion &&
         !previousSection.hasCopyTokens &&
+        !previousSection.alwaysVisible &&
         previousSection.type !== "diff"
       ) {
         previousSection.isExpanded = false;
@@ -888,6 +892,11 @@ export default class CommandExecution extends SharedMixin(LightningElement) {
     // If this section contains copy values, keep it expanded by default
     if (this.containsCopyMarkup(formattedLog.message)) {
       this.currentSection.hasCopyTokens = true;
+    }
+
+    // A non-action log flagged alwaysVisible keeps its enclosing section expanded by default
+    if (logLine.alwaysVisible === true) {
+      this.currentSection.alwaysVisible = true;
     }
 
     this.currentSection.logs = [...this.currentSection.logs, formattedLog];
@@ -1364,6 +1373,9 @@ ${resultMessage}`;
       // By default, question sections and progress sections are expanded, but user can collapse them
       if (this.userSectionExpandState.hasOwnProperty(section.id)) {
         isExpanded = this.userSectionExpandState[section.id];
+      } else if (section.alwaysVisible) {
+        // Sections explicitly flagged alwaysVisible stay open in both simple and advanced modes
+        isExpanded = true;
       } else if (section.isQuestion) {
         isExpanded = true;
       } else if (isProgress) {


### PR DESCRIPTION
Enhances the user support experience:
- **Intelligent Issue Reporting:** The "Post an issue on GitHub" help menu entry now first attempts to run `sf hardis:doctor` to collect diagnostics and guide users in creating well-formed issues. If the `sfdx-hardis` plugin is not installed, it gracefully falls back to opening the GitHub issues page.
- **Updated Support Contact:** Renames the "Contact us to get help" entry to "Get assistance from Cloudity" in the help menu across all supported languages.
- **Improved Command Output Visibility:** Introduces an `alwaysVisible` flag for command log sections in the UI, ensuring crucial diagnostic output, such as that from `sf hardis:doctor`, remains expanded and accessible to the user.