### PR TITLE
feat: Integrate metadata presets into type selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Metadata Retriever
+  - Added **presets**: reusable groups of metadata types that you can select to search and retrieve several metadata types at once
+    - Presets appear at the top of the **Metadata Type** list, marked with a ⭐, right after the **All** entry
+    - Use the **Manage presets** button to open `.sfdx-hardis.yml` and create or edit your own presets
+
 - Deployment Actions
   - Added support for the new **Remove package.xml Items** action type, which removes selected metadata items from the deployment's package.xml before the metadata is deployed
     - Enter one entry per line using the `TypeName:Member1,Member2` format, or use `*` as the member to remove a whole metadata type

--- a/src/webviews/lwc-ui/modules/s/metadataRetriever/metadataRetriever.html
+++ b/src/webviews/lwc-ui/modules/s/metadataRetriever/metadataRetriever.html
@@ -46,19 +46,8 @@
       <!-- Filters Section -->
       <div class="slds-p-around_x-small">
         <div class="slds-grid slds-gutters_x-small slds-wrap">
-          <!-- Metadata Preset Filter (group of metadata types defined in .sfdx-hardis.yml) -->
-          <div class="slds-col slds-size_1-of-1 slds-medium-size_1-of-3 slds-large-size_1-of-6">
-            <lightning-combobox
-              label={i18n.metadataPresetLabel}
-              value={selectedPreset}
-              options={presetOptions}
-              onchange={handlePresetChange}
-              placeholder={i18n.selectMetadataPreset}
-              title={presetTooltip}
-            ></lightning-combobox>
-          </div>
-
-          <!-- Metadata Type Filter (typeahead: filter the list by typing) -->
+          <!-- Metadata Type Filter (typeahead: filter the list by typing).
+               Presets (⭐) are listed right after "All". -->
           <div class="slds-col slds-size_1-of-1 slds-medium-size_1-of-3 slds-large-size_1-of-6">
             <s-typeahead
               label={i18n.metadataTypeLabel}
@@ -67,7 +56,6 @@
               onchange={handleMetadataTypeChange}
               placeholder={metadataTypePlaceholder}
               required={metadataTypeRequired}
-              disabled={metadataTypeDisabled}
             ></s-typeahead>
           </div>
 
@@ -166,15 +154,6 @@
             ></lightning-button>
             <lightning-button
               variant="neutral"
-              label={i18n.managePresets}
-              icon-name="utility:settings"
-              onclick={handleManagePresets}
-              size="small"
-              class="slds-m-right_small"
-              title={i18n.managePresetsTooltip}
-            ></lightning-button>
-            <lightning-button
-              variant="neutral"
               label={i18n.clearFilters}
               icon-name="utility:clear"
               onclick={handleClearFilters}
@@ -187,6 +166,15 @@
               icon-name="utility:real_time"
               onclick={handleViewHistory}
               size="small"
+              class="slds-m-right_small"
+            ></lightning-button>
+            <lightning-button
+              variant="neutral"
+              label={i18n.managePresets}
+              icon-name="utility:settings"
+              onclick={handleManagePresets}
+              size="small"
+              title={i18n.managePresetsTooltip}
             ></lightning-button>
           </div>
           <div class="slds-col slds-no-flex slds-form-element slds-form-element_compact">

--- a/src/webviews/lwc-ui/modules/s/metadataRetriever/metadataRetriever.js
+++ b/src/webviews/lwc-ui/modules/s/metadataRetriever/metadataRetriever.js
@@ -11,6 +11,11 @@ import { SharedMixin } from "s/sharedMixin";
 const METADATA_DOC_BASE_URL =
   "https://sf-explorer.github.io/sf-doc-to-json/#/cloud/all/object/";
 
+// Presets are surfaced inside the metadata type list (right after "All").
+// Their option value is prefixed so we can tell a preset selection apart from
+// a single metadata type selection.
+const PRESET_VALUE_PREFIX = "preset::";
+
 export default class MetadataRetriever extends SharedMixin(LightningElement) {
   // Panel-level loading state (true until init data arrives from backend)
   @track panelLoading = true;
@@ -238,9 +243,21 @@ export default class MetadataRetriever extends SharedMixin(LightningElement) {
       this.queryMode === "allMetadata"
         ? []
         : [{ label: this.t("allLabel"), value: "All" }];
+    // Presets (groups of metadata types defined in .sfdx-hardis.yml) are listed
+    // right after "All" so the user can pick a whole group from the same field
+    // instead of a separate combobox. Their value is prefixed to distinguish
+    // them from single metadata types.
+    if (this.metadataPresets && Array.isArray(this.metadataPresets)) {
+      for (const preset of this.metadataPresets) {
+        options.push({
+          label: `⭐ ${preset.label}`,
+          value: `${PRESET_VALUE_PREFIX}${preset.id}`,
+        });
+      }
+    }
     if (this.metadataTypes && Array.isArray(this.metadataTypes)) {
       // Strip non-combobox properties (e.g. inFolder) before passing to
-      // lightning-combobox so it doesn't complain about unknown options.
+      // the typeahead so it doesn't complain about unknown options.
       const cleaned = this.metadataTypes.map((mt) => ({
         label: mt.label,
         value: mt.value,
@@ -251,17 +268,6 @@ export default class MetadataRetriever extends SharedMixin(LightningElement) {
   }
 
   // --- Metadata presets (groups of metadata types) ---------------------------
-
-  // Options of the preset combobox: "No preset" + presets from .sfdx-hardis.yml
-  get presetOptions() {
-    const options = [{ label: this.t("noPresetLabel"), value: "" }];
-    if (this.metadataPresets && Array.isArray(this.metadataPresets)) {
-      for (const preset of this.metadataPresets) {
-        options.push({ label: preset.label, value: preset.id });
-      }
-    }
-    return options;
-  }
 
   get selectedPresetObject() {
     if (!this.selectedPreset || !Array.isArray(this.metadataPresets)) {
@@ -297,27 +303,14 @@ export default class MetadataRetriever extends SharedMixin(LightningElement) {
     });
   }
 
-  get presetTooltip() {
-    const preset = this.selectedPresetObject;
-    return preset && preset.description
-      ? preset.description
-      : this.t("metadataPresetTooltip");
-  }
-
-  // A preset drives the metadata types, so the single-type field is disabled
-  get metadataTypeDisabled() {
-    return this.isPresetSelected;
-  }
-
-  // The single metadata type is only mandatory when no preset is selected
+  // The metadata type field is mandatory in All Metadata mode when neither a
+  // single type nor a preset is selected.
   get metadataTypeRequired() {
     return this.isAllMetadataMode && !this.isPresetSelected;
   }
 
   get metadataTypePlaceholder() {
-    return this.isPresetSelected
-      ? this.t("metadataTypeDisabledByPreset")
-      : this.t("selectMetadataType");
+    return this.t("selectMetadataType");
   }
 
   get hasQueryProgress() {
@@ -767,17 +760,6 @@ export default class MetadataRetriever extends SharedMixin(LightningElement) {
     setTimeout(() => this.checkRetrieveButtonVisibility(), 0);
   }
 
-  handlePresetChange(event) {
-    this.selectedPreset = event.detail.value || "";
-    // A preset replaces the single metadata type selection
-    if (this.isPresetSelected) {
-      this.metadataType = this.isAllMetadataMode ? "" : "All";
-      this.selectedFolder = "";
-      this.folderOptions = [];
-    }
-    this.applyFilters();
-  }
-
   // Open .sfdx-hardis.yml to create or update presets. Defaults are written in
   // the file when it does not declare any preset yet.
   handleManagePresets() {
@@ -788,7 +770,15 @@ export default class MetadataRetriever extends SharedMixin(LightningElement) {
   }
 
   handleMetadataTypeChange(event) {
-    this.metadataType = event.detail.value;
+    const value = event.detail.value;
+    this.metadataType = value;
+    // A preset is encoded in the same list with a prefixed value. Derive the
+    // selected preset (or clear it when a single metadata type is chosen).
+    if (value && value.startsWith(PRESET_VALUE_PREFIX)) {
+      this.selectedPreset = value.slice(PRESET_VALUE_PREFIX.length);
+    } else {
+      this.selectedPreset = "";
+    }
     // Reset folder selection whenever the metadata type changes
     this.selectedFolder = "";
     this.folderOptions = [];
@@ -1297,6 +1287,9 @@ export default class MetadataRetriever extends SharedMixin(LightningElement) {
       // The selected preset may have been renamed or removed from the config file
       if (this.selectedPreset && !this.isPresetSelected) {
         this.selectedPreset = "";
+        // Reset the metadata type field, which was displaying the stale preset
+        this.metadataType = this.isAllMetadataMode ? "" : "All";
+        this.applyFilters();
       }
     }
   }


### PR DESCRIPTION
Consolidates the selection of metadata types and predefined presets into a single input field. This change removes the dedicated preset combobox and instead lists presets (marked with a ⭐) directly within the main metadata type list, improving the user experience and streamlining the selection process. The 'Manage presets' button has also been repositioned.
