### PR TITLE
fix(ui): readable tooltip text in dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
     - All dialog windows (Data Workbench, Files Workbench, Pipeline Config, Monitoring Config, Deployment Actions) open with the same brand accent strip as the pull requests modal
   - Quick action cards and other panels (Org Monitoring, Package XML, Documentation, Welcome, Setup, Monitoring Config, Metadata Retriever) now use the official Salesforce color palette for their icons and buttons
   - Deployment action execution contexts were renamed for clarity: "Validation and Deployment jobs", "Validation job only" and "Deployment job only" (previously "Check job" and "Process Deployment job"), in all languages
+  - Fix help tooltips that displayed black text on their dark blue background in dark mode, making them nearly impossible to read: their text is now light in dark mode, in every panel ([#2051](https://github.com/hardisgroupcom/sfdx-hardis/issues/2051))
 
 - Performance
   - Commands launched from the menu now open their execution tab **immediately** when clicked, instead of after the Salesforce CLI finished booting (which could take more than 10 seconds)

--- a/resources/global-theme.css
+++ b/resources/global-theme.css
@@ -647,6 +647,22 @@ div.slds-scope[data-theme="dark"] {
     color: #cbd5e1;
 }
 
+/* ------------------------------------------------------------------ */
+/* Tooltips (lightning-helptext + s-multiline-helptext)                */
+/* SLDS styles .slds-popover_tooltip from two tokens that both invert   */
+/* between themes: --slds-g-color-brand-base-20 for the bubble and      */
+/* --slds-g-color-neutral-base-100 for the text. In dark mode the text  */
+/* token resolves to #000, which rendered black text on the dark navy   */
+/* bubble. The text color is set by SLDS on .slds-popover__body itself, */
+/* so it cannot be fixed by coloring the bubble alone - pin the two     */
+/* documented tooltip styling hooks instead, so every tooltip keeps a   */
+/* dark bubble with light text in both themes.                          */
+/* ------------------------------------------------------------------ */
+.slds-scope[data-theme] {
+    --slds-c-tooltip-color-background: light-dark(#032d60, #0b2236);
+    --slds-c-tooltip-text-color: light-dark(#ffffff, #e6eef9);
+}
+
 .slds-scope[data-theme="dark"] .select-option-label {
     color: #ffffff;
 }

--- a/src/webviews/lwc-ui/modules/s/multilineHelptext/multilineHelptext.css
+++ b/src/webviews/lwc-ui/modules/s/multilineHelptext/multilineHelptext.css
@@ -16,12 +16,19 @@
     align-items: center;
 }
 
+/* Theme-aware colors: this CSS is scoped to the component, so selectors based
+   on the <body> theme attribute (.slds-scope[data-theme] ...) can never match
+   from here - LWC appends the scope token to every compound selector. Use
+   light-dark(), which follows the color-scheme set by global-theme-variables.css
+   on the themed body, and the SLDS tooltip styling hooks pinned in
+   global-theme.css for anything SLDS colors itself. */
 .multiline-helptext-popover {
     position: absolute;
-    background: #032d60;
-    color: #fff;
+    background: var(--slds-c-tooltip-color-background, #032d60);
+    color: var(--slds-c-tooltip-text-color, #fff);
+    border: 1px solid light-dark(transparent, rgba(255, 255, 255, 0.06));
     border-radius: 8px;
-    box-shadow: 0 2px 8px #0002;
+    box-shadow: light-dark(0 2px 8px rgba(0, 0, 0, 0.13), 0 6px 18px rgba(0, 0, 0, 0.6));
     padding: 0.5rem;
     font-size: 14px;
     z-index: 2147483647;
@@ -34,35 +41,12 @@
     user-select: text;
 }
 
-/* Light theme (explicit) */
-.slds-scope[data-theme] .multiline-helptext-popover {
-    background: #032d60;
-    color: #fff;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.13);
+.multiline-helptext-popover a {
+    color: light-dark(#87ceeb, #7fc7ff);
 }
 
-.slds-scope[data-theme] .multiline-helptext-popover a {
-    color: #87ceeb;
-}
-
-.slds-scope[data-theme] .multiline-helptext-popover a:hover {
-    color: #b0e0e6;
-}
-
-/* Dark theme overrides (component-scoped) */
-.blue-back[data-theme="dark"] .multiline-helptext-popover {
-    background: #0b2236; /* slightly lighter than surrounding bg */
-    color: #e6eef9;
-    box-shadow: 0 6px 18px rgba(0,0,0,0.6);
-    border: 1px solid rgba(255,255,255,0.04);
-}
-
-.blue-back[data-theme="dark"] .multiline-helptext-popover a {
-    color: #7fc7ff;
-}
-
-.blue-back[data-theme="dark"] .multiline-helptext-popover a:hover {
-    color: #bde8ff;
+.multiline-helptext-popover a:hover {
+    color: light-dark(#b0e0e6, #bde8ff);
 }
 
 /* Horizontal positioning */
@@ -87,6 +71,9 @@
     transform: translateY(50%);
 }
 
+/* SLDS colors .slds-popover__body directly, so the popover text color is not
+   inherited from the bubble - it has to be overridden on the body element. */
 .multiline-helptext-popover .slds-popover__body {
     padding: 0;
+    color: inherit;
 }


### PR DESCRIPTION
Fixes [hardisgroupcom/sfdx-hardis#2051](https://github.com/hardisgroupcom/sfdx-hardis/issues/2051)

## Problem

In dark mode, help tooltips rendered **black text on their dark navy background**, making them nearly impossible to read — reported by a user with vision issues.

## Root cause

SLDS colors the tooltip *body* separately from the bubble:

```css
.slds-popover_tooltip .slds-popover__body {
  color: var(--slds-c-tooltip-text-color,
          ... var(--slds-g-color-neutral-base-100, #fff));
}
```

and `resources/global-theme-variables.css` defines `--slds-g-color-neutral-base-100: light-dark(#fff, #000)` → **`#000` in dark mode**.

`multilineHelptext.css` did set `color: #fff`, but only on the popover *parent*, so it lost to the SLDS rule targeting the child element.

Confirmed by pixel-sampling the screenshots from the issue: the background is `#0f2e5d` in **both** themes, while the text is `#ffffff` in light and `#000000` in dark.

A second, silent bug was found along the way: the component's dark-theme block

```css
.blue-back[data-theme="dark"] .multiline-helptext-popover { ... }
```

was **dead code**. LWC appends the scope token to *every* compound selector, so a selector starting at the themed `<body>` can never match from component CSS. Verified in the compiled bundle.

## Fix

- **`resources/global-theme.css`** — pin the two documented SLDS tooltip styling hooks on `.slds-scope[data-theme]`:
  - `--slds-c-tooltip-color-background: light-dark(#032d60, #0b2236)`
  - `--slds-c-tooltip-text-color: light-dark(#fff, #e6eef9)`

  This is a global sheet, so it fixes **both** tooltip flavors: the custom `s-multiline-helptext` popover and the stock `lightning-helptext` (used in `promptInput`), which had the exact same defect.

- **`src/webviews/lwc-ui/modules/s/multilineHelptext/multilineHelptext.css`** — read those tokens instead of hardcoding, add `color: inherit` on `.slds-popover__body` so it can never fall back to the inverting token, and replace the dead theme-selector blocks with working `light-dark()` values (border, shadow, link colors).

Dark mode now renders a slightly lifted navy bubble (`#0b2236`) with near-white text (`#e6eef9`) — the look the original author intended but whose selectors never matched. Light mode is unchanged.

## Checks

- `yarn dev` ✅ (only the pre-existing `isCSR` warning)
- `yarn lint` ✅
- Verified the emitted `out/assets/styles/global-theme.css` and the compiled scoped component CSS contain the new rules

Not verified visually in a running Extension Development Host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
