### PR TITLE
fix(setup): show Upgrade button instead of Fix Instructions for outdated sfdx-hardis plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@
   - The panel now shows an **Upgrade** button that directly installs the required version
   - The card now shows the same warning icon as other upgrades (on the red "required" accent), instead of the same icon as a broken dependency
   - When **Auto-update dependencies** is enabled, the upgrade now runs automatically too
+  - Upgrading from the deprecated sfdx-cli package now runs the correct replacement command
 - Fixed VS Code freezing for several seconds at startup while checking the installed Salesforce CLI plugins
-  - The check no longer dumps the multi-megabyte plugin list JSON into the SFDX Hardis output channel (over 100 000 lines) and no longer stores it in the extension storage
-  - Large cached values in general are now kept in files on disk instead of the extension storage, whose size was slowing down every VS Code save of extension state
+  - The SFDX Hardis output channel is no longer flooded with huge command outputs
 
 ## [8.0.1] 2026-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 - Fixed the Install Dependencies panel showing a useless **Fix Instructions** button (leading to the sfdx-hardis repository) when the installed sfdx-hardis plugin is older than the required version
   - The panel now shows an **Upgrade** button that directly installs the required version
+  - The card now shows the same warning icon as other upgrades (on the red "required" accent), instead of the same icon as a broken dependency
   - When **Auto-update dependencies** is enabled, the upgrade now runs automatically too
+- Fixed VS Code freezing for several seconds at startup while checking the installed Salesforce CLI plugins
+  - The check no longer dumps the multi-megabyte plugin list JSON into the SFDX Hardis output channel (over 100 000 lines) and no longer stores it in the extension storage
 
 ## [8.0.1] 2026-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - When **Auto-update dependencies** is enabled, the upgrade now runs automatically too
 - Fixed VS Code freezing for several seconds at startup while checking the installed Salesforce CLI plugins
   - The check no longer dumps the multi-megabyte plugin list JSON into the SFDX Hardis output channel (over 100 000 lines) and no longer stores it in the extension storage
+  - Large cached values in general are now kept in files on disk instead of the extension storage, whose size was slowing down every VS Code save of extension state
 
 ## [8.0.1] 2026-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Fixed the Install Dependencies panel showing a useless **Fix Instructions** button (leading to the sfdx-hardis repository) when the installed sfdx-hardis plugin is older than the required version
+  - The panel now shows an **Upgrade** button that directly installs the required version
+  - When **Auto-update dependencies** is enabled, the upgrade now runs automatically too
+
 ## [8.0.1] 2026-08-21
 
 - Set default theme as light

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,7 +32,9 @@ let welcomeShownThisSession = false; // Flag to track if welcome was shown this 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
-  CacheManager.init(context.globalState);
+  // Large cached values are offloaded to files under globalStorage: globalState
+  // itself is serialized synchronously on every update, so it must stay small
+  CacheManager.init(context.globalState, context.globalStorageUri.fsPath);
   CacheManager.clearExpired();
   SecretsManager.init(context);
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -27,6 +27,12 @@ function isPerfDebugEnabled(): boolean {
   return perfDebugEnabled;
 }
 
+// A single log call can carry a multi-MB CLI output (e.g. a failed
+// `sf plugins install ...` dump): each line is one appendLine RPC to the
+// renderer, so an oversized message freezes the extension host. Capped here so
+// every caller is covered, success and error paths alike.
+const MAX_LOGGED_CHARS = 100_000;
+
 export class Logger {
   outputChannel: any;
 
@@ -42,13 +48,19 @@ export class Logger {
   }
 
   static log(str: any): void {
+    let text = String(str ?? "");
+    if (text.length > MAX_LOGGED_CHARS) {
+      text =
+        text.slice(0, MAX_LOGGED_CHARS) +
+        `\n[vscode-sfdx-hardis] ... output truncated in this log (${text.length} characters total)`;
+    }
     if (loggerInstance) {
-      console.log(str);
-      for (const line of str.toString().split("\n")) {
+      console.log(text);
+      for (const line of text.split("\n")) {
         loggerInstance.outputChannelLog(line);
       }
     } else {
-      console.log(str);
+      console.log(text);
     }
   }
 

--- a/src/test/suite/cacheManager.test.ts
+++ b/src/test/suite/cacheManager.test.ts
@@ -134,4 +134,41 @@ suite("CacheManager large value offload", () => {
     assert.strictEqual(listLargeCacheFiles().length, 0);
     assert.strictEqual(CacheManager.get("app", "huge"), undefined);
   });
+
+  test("a rejected oversized overwrite keeps the previous cached value and its file", async () => {
+    const value = bigValue();
+    await CacheManager.set("app", "key", value, 60_000);
+    await CacheManager.set("app", "key", "y".repeat(21_000_000), 60_000);
+    assert.strictEqual(listLargeCacheFiles().length, 1);
+    assert.deepStrictEqual(CacheManager.get("app", "key"), value);
+    // Also from the file, not just from the in-memory memo
+    (CacheManager as any).largeValueMemo.clear();
+    assert.deepStrictEqual(CacheManager.get("app", "key"), value);
+  });
+
+  test("a non-serializable overwrite keeps the previous cached value", async () => {
+    await CacheManager.set("app", "key", { a: 1 }, 60_000);
+    const cyclic: any = {};
+    cyclic.self = cyclic;
+    await CacheManager.set("app", "key", cyclic, 60_000);
+    assert.deepStrictEqual(CacheManager.get("app", "key"), { a: 1 });
+  });
+
+  test("a corrupted file behaves as a cache miss and cleans the entry", async () => {
+    await CacheManager.set("app", "big", bigValue(), 60_000);
+    (CacheManager as any).largeValueMemo.clear();
+    for (const f of listLargeCacheFiles()) {
+      fs.writeFileSync(path.join(largeCacheDir(), f), "{ not json", "utf8");
+    }
+    assert.strictEqual(CacheManager.get("app", "big"), undefined);
+    // get() fires the cleanup delete() without awaiting it
+    await new Promise((r) => setImmediate(r));
+    assert.strictEqual(fakeStore.get("app:big"), undefined);
+  });
+
+  test("no temp file is left behind after a large value write", async () => {
+    await CacheManager.set("app", "big", bigValue(), 60_000);
+    const tmpFiles = listLargeCacheFiles().filter((f) => f.endsWith(".tmp"));
+    assert.strictEqual(tmpFiles.length, 0);
+  });
 });

--- a/src/test/suite/cacheManager.test.ts
+++ b/src/test/suite/cacheManager.test.ts
@@ -40,7 +40,9 @@ suite("CacheManager large value offload", () => {
   }
 
   function listLargeCacheFiles(): string[] {
-    return fs.existsSync(largeCacheDir()) ? fs.readdirSync(largeCacheDir()) : [];
+    return fs.existsSync(largeCacheDir())
+      ? fs.readdirSync(largeCacheDir())
+      : [];
   }
 
   setup(() => {

--- a/src/test/suite/cacheManager.test.ts
+++ b/src/test/suite/cacheManager.test.ts
@@ -1,0 +1,135 @@
+import * as assert from "assert";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { CacheManager } from "../../utils/cache-manager";
+
+// Minimal vscode.Memento stand-in backed by a Map
+class FakeMemento {
+  private map = new Map<string, any>();
+  keys(): readonly string[] {
+    return [...this.map.keys()];
+  }
+  get<T>(key: string, defaultValue?: T): T | undefined {
+    return this.map.has(key) ? this.map.get(key) : defaultValue;
+  }
+  update(key: string, value: any): Thenable<void> {
+    if (value === undefined) {
+      this.map.delete(key);
+    } else {
+      this.map.set(key, value);
+    }
+    return Promise.resolve();
+  }
+}
+
+// Above the offload threshold (100k chars serialized)
+function bigValue() {
+  return { data: "x".repeat(200_000), nested: { ok: true } };
+}
+
+suite("CacheManager large value offload", () => {
+  let fakeStore: FakeMemento;
+  let tmpDir: string;
+  let savedStore: any;
+  let savedDir: any;
+  let savedMemo: any;
+
+  function largeCacheDir(): string {
+    return path.join(tmpDir, "large-cache");
+  }
+
+  function listLargeCacheFiles(): string[] {
+    return fs.existsSync(largeCacheDir()) ? fs.readdirSync(largeCacheDir()) : [];
+  }
+
+  setup(() => {
+    // CacheManager is a static singleton initialized by the activated
+    // extension: save its state and restore it in teardown
+    savedStore = (CacheManager as any).store;
+    savedDir = (CacheManager as any).largeValueDir;
+    savedMemo = (CacheManager as any).largeValueMemo;
+    fakeStore = new FakeMemento();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "hardis-cache-test-"));
+    CacheManager.init(fakeStore as any, tmpDir);
+  });
+
+  teardown(() => {
+    (CacheManager as any).store = savedStore;
+    (CacheManager as any).largeValueDir = savedDir;
+    (CacheManager as any).largeValueMemo = savedMemo;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("small values stay inline in the memento", async () => {
+    await CacheManager.set("app", "small", { a: 1 }, 60_000);
+    const entry: any = fakeStore.get("app:small");
+    assert.deepStrictEqual(entry.value, { a: 1 });
+    assert.strictEqual(entry.largeValueFile, undefined);
+    assert.deepStrictEqual(CacheManager.get("app", "small"), { a: 1 });
+    assert.strictEqual(listLargeCacheFiles().length, 0);
+  });
+
+  test("large values are offloaded to a file, memento keeps only its name", async () => {
+    const value = bigValue();
+    await CacheManager.set("app", "big", value, 60_000);
+    const entry: any = fakeStore.get("app:big");
+    assert.strictEqual(entry.value, undefined);
+    assert.ok(entry.largeValueFile, "entry must reference a file");
+    assert.strictEqual(listLargeCacheFiles().length, 1);
+    assert.deepStrictEqual(CacheManager.get("app", "big"), value);
+  });
+
+  test("large value survives a memo reset (read back from the file)", async () => {
+    const value = bigValue();
+    await CacheManager.set("app", "big", value, 60_000);
+    (CacheManager as any).largeValueMemo.clear();
+    assert.deepStrictEqual(CacheManager.get("app", "big"), value);
+  });
+
+  test("a removed file behaves as a cache miss and cleans the entry", async () => {
+    await CacheManager.set("app", "big", bigValue(), 60_000);
+    (CacheManager as any).largeValueMemo.clear();
+    for (const f of listLargeCacheFiles()) {
+      fs.unlinkSync(path.join(largeCacheDir(), f));
+    }
+    assert.strictEqual(CacheManager.get("app", "big"), undefined);
+  });
+
+  test("delete removes the file", async () => {
+    await CacheManager.set("app", "big", bigValue(), 60_000);
+    assert.strictEqual(listLargeCacheFiles().length, 1);
+    await CacheManager.delete("app", "big");
+    assert.strictEqual(listLargeCacheFiles().length, 0);
+    assert.strictEqual(CacheManager.get("app", "big"), undefined);
+  });
+
+  test("expired large value is cleaned up with its file", async () => {
+    await CacheManager.set("app", "big", bigValue(), -1);
+    assert.strictEqual(CacheManager.get("app", "big"), undefined);
+    assert.strictEqual(listLargeCacheFiles().length, 0);
+  });
+
+  test("clearExpired removes expired large value files", async () => {
+    await CacheManager.set("app", "big", bigValue(), -1);
+    await CacheManager.set("app", "keep", bigValue(), 60_000);
+    await CacheManager.clearExpired();
+    assert.strictEqual(listLargeCacheFiles().length, 1);
+    assert.deepStrictEqual(CacheManager.get("app", "keep"), bigValue());
+  });
+
+  test("overwriting a large value with a small one removes the old file", async () => {
+    await CacheManager.set("app", "key", bigValue(), 60_000);
+    assert.strictEqual(listLargeCacheFiles().length, 1);
+    await CacheManager.set("app", "key", { small: true }, 60_000);
+    assert.strictEqual(listLargeCacheFiles().length, 0);
+    assert.deepStrictEqual(CacheManager.get("app", "key"), { small: true });
+  });
+
+  test("values above the absolute cap are not cached at all", async () => {
+    await CacheManager.set("app", "huge", "y".repeat(21_000_000), 60_000);
+    assert.strictEqual(fakeStore.get("app:huge"), undefined);
+    assert.strictEqual(listLargeCacheFiles().length, 0);
+    assert.strictEqual(CacheManager.get("app", "huge"), undefined);
+  });
+});

--- a/src/test/suite/pluginsVersionUtils.test.ts
+++ b/src/test/suite/pluginsVersionUtils.test.ts
@@ -4,6 +4,7 @@ import {
   getPluginInstallKindFromInfo,
   getPluginInstallKindFromText,
   mustUpgradeSfdxHardisPlugin,
+  parsePluginsData,
   parsePluginsJson,
   stripAnsiCodes,
 } from "../../utils/pluginsVersionUtils";
@@ -162,6 +163,61 @@ suite("pluginsVersionUtils", () => {
       assert.strictEqual(getPluginInstallKindFromInfo(null), "missing");
       assert.deepStrictEqual(parsePluginsJson("not json at all"), {});
       assert.deepStrictEqual(parsePluginsJson(""), {});
+    });
+  });
+
+  suite("parsePluginsData", () => {
+    test("parses an already parsed array (execCommand --json result)", () => {
+      const plugins = parsePluginsData(JSON.parse(PLUGINS_JSON_LINKED));
+      assert.strictEqual(plugins["sfdx-hardis"].version, "7.23.0");
+      assert.strictEqual(
+        getPluginInstallKindFromInfo(plugins["sfdx-hardis"]),
+        "localdev",
+      );
+    });
+    test("parses a { status, result } envelope and keeps the alias", () => {
+      const plugins = parsePluginsData({
+        status: 0,
+        result: [
+          {
+            name: "packaging",
+            alias: "@salesforce/plugin-packaging",
+            version: "3.0.5",
+            type: "user",
+            tag: "latest",
+          },
+        ],
+      });
+      assert.strictEqual(
+        plugins["packaging"].alias,
+        "@salesforce/plugin-packaging",
+      );
+    });
+    test("keeps only the trimmed fields, dropping the oclif manifest", () => {
+      const plugins = parsePluginsData([
+        {
+          name: "sfdmu",
+          version: "5.8.0",
+          type: "user",
+          tag: "latest",
+          root: "C:\\somewhere",
+          commandIDs: ["a", "b"],
+          commands: [{ id: "a", flags: {} }],
+        },
+      ]);
+      assert.deepStrictEqual(Object.keys(plugins["sfdmu"]).sort(), [
+        "alias",
+        "name",
+        "root",
+        "tag",
+        "type",
+        "version",
+      ]);
+    });
+    test("returns an empty map for unusable payloads", () => {
+      assert.deepStrictEqual(parsePluginsData(null), {});
+      assert.deepStrictEqual(parsePluginsData("string"), {});
+      assert.deepStrictEqual(parsePluginsData({ status: 1 }), {});
     });
   });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -75,14 +75,14 @@ export async function getInstalledPluginsInfo(): Promise<
       typeof res?.stdout === "string" && res.stdout
         ? parsePluginsJson(res.stdout)
         : parsePluginsData(res);
-    if (Object.keys(pluginsInfo).length > 0) {
-      await CacheManager.set(
-        "app",
-        "installedPluginsInfo",
-        pluginsInfo,
-        1000 * 60 * 5, // 5 minutes
-      );
-    }
+    // An empty result (CLI not installed, transient failure) is cached too,
+    // with a short TTL: without it, every dependency card and menu builder
+    // would re-spawn the multi-second `sf plugins --json` command in a loop
+    const ttlMs =
+      Object.keys(pluginsInfo).length > 0
+        ? 1000 * 60 * 5 // 5 minutes
+        : 1000 * 60; // 1 minute
+    await CacheManager.set("app", "installedPluginsInfo", pluginsInfo, ttlMs);
     return pluginsInfo;
   } catch (e: any) {
     Logger.log("Unable to list installed plugins as JSON: " + e?.message);
@@ -600,20 +600,6 @@ export async function execSfdxJsonWithProgress(
 }
 /* jscpd:ignore-end */
 
-// Commands like `sf plugins --json` return multi-MB payloads: dumping them
-// line by line in the output channel freezes the extension host (each line is
-// an RPC to the renderer), so displayed output is capped.
-const MAX_LOGGED_OUTPUT_CHARS = 100_000;
-function truncateLoggedOutput(output: string, command: string): string {
-  if (output.length <= MAX_LOGGED_OUTPUT_CHARS) {
-    return output;
-  }
-  return (
-    output.slice(0, MAX_LOGGED_OUTPUT_CHARS) +
-    `\n[vscode-sfdx-hardis] ... output truncated in this log (${output.length} characters total for command "${command}")`
-  );
-}
-
 // Execute command
 export async function execCommand(
   command: string,
@@ -716,8 +702,9 @@ export async function execCommand(
     return res;
   }
   // Display output if requested, for better user understanding of the logs
+  // (Logger.log caps oversized outputs like the multi-MB `sf plugins --json`)
   if (options.output || options.debug) {
-    Logger.log(truncateLoggedOutput(commandResult.stdout.toString(), command));
+    Logger.log(commandResult.stdout.toString());
   }
   // Return status 0 if not --json
   if (!command.includes("--json")) {
@@ -753,16 +740,20 @@ export async function execCommand(
     }
     return parsedResult;
   } catch (e: any) {
-    // Manage case when json is not parsable
+    // Manage case when json is not parsable (e.g. warning lines printed before
+    // the JSON payload). The raw stdout is returned so callers can attempt
+    // their own recovery, and NOTHING is cached: caching this error object for
+    // a long TTL would pin a multi-MB garbage payload and mask the next
+    // successful run.
     const errorObj = {
       status: 1,
+      stdout: (commandResult.stdout ?? "").toString(),
+      stderr: (commandResult.stderr ?? "").toString(),
+      unableToParseJson: true,
       errorMessage: c.red(
         `[sfdx-hardis][ERROR] Error parsing JSON in command result: ${e.message}\n${commandResult.stdout}\n${commandResult.stderr})`,
       ),
     };
-    if (cacheSection && typeof cacheExpiration === "number") {
-      CacheManager.set(cacheSection, command, errorObj, cacheExpiration);
-    }
     return errorObj;
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -618,7 +618,9 @@ function truncateLoggedOutput(output: string, command: string): string {
 // update: caching a multi-MB command result stalls the extension host and
 // triggers the VS Code "large extension state detected" warning. Oversized
 // results are simply not cached; callers must cache a trimmed value instead.
-const MAX_CACHED_RESULT_CHARS = 500_000;
+// The threshold is far above any legitimate cached result (org lists, metadata
+// folder lists) while still rejecting the `sf plugins --json` manifest (4+ MB).
+const MAX_CACHED_RESULT_CHARS = 1_000_000;
 function isCacheableCommandResult(command: string, value: any): boolean {
   try {
     const size = JSON.stringify(value)?.length ?? 0;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -614,28 +614,6 @@ function truncateLoggedOutput(output: string, command: string): string {
   );
 }
 
-// globalState (backing CacheManager) is serialized synchronously on every
-// update: caching a multi-MB command result stalls the extension host and
-// triggers the VS Code "large extension state detected" warning. Oversized
-// results are simply not cached; callers must cache a trimmed value instead.
-// The threshold is far above any legitimate cached result (org lists, metadata
-// folder lists) while still rejecting the `sf plugins --json` manifest (4+ MB).
-const MAX_CACHED_RESULT_CHARS = 1_000_000;
-function isCacheableCommandResult(command: string, value: any): boolean {
-  try {
-    const size = JSON.stringify(value)?.length ?? 0;
-    if (size > MAX_CACHED_RESULT_CHARS) {
-      Logger.log(
-        `[vscode-sfdx-hardis][WARNING] Result of "${command}" is too large to be cached (${size} characters): cache a trimmed value instead`,
-      );
-      return false;
-    }
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 // Execute command
 export async function execCommand(
   command: string,
@@ -751,8 +729,7 @@ export async function execCommand(
     if (
       cacheSection &&
       typeof cacheExpiration === "number" &&
-      !CacheManager.get(cacheSection, command) &&
-      isCacheableCommandResult(command, resultObj)
+      !CacheManager.get(cacheSection, command)
     ) {
       CacheManager.set(cacheSection, command, resultObj, cacheExpiration);
     }
@@ -771,11 +748,7 @@ export async function execCommand(
         "[sfdx-hardis][WARNING] stderr: " + c.yellow(commandResult.stderr),
       );
     }
-    if (
-      cacheSection &&
-      typeof cacheExpiration === "number" &&
-      isCacheableCommandResult(command, parsedResult)
-    ) {
+    if (cacheSection && typeof cacheExpiration === "number") {
       CacheManager.set(cacheSection, command, parsedResult, cacheExpiration);
     }
     return parsedResult;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,6 +17,7 @@ import {
   PluginInstallKind,
   getPluginInstallKindFromInfo,
   getPluginInstallKindFromText,
+  parsePluginsData,
   parsePluginsJson,
 } from "./utils/pluginsVersionUtils";
 
@@ -53,13 +54,36 @@ export async function getInstalledPluginsInfo(): Promise<
   Record<string, InstalledPluginInfo>
 > {
   try {
+    // Cache only the trimmed plugin infos, NEVER the raw `sf plugins --json`
+    // payload: it embeds the whole oclif manifest of every plugin (several MB),
+    // which used to bloat globalState (4+ MB serialized on every cache write)
+    // and flood the output channel, freezing the extension host at startup
+    const cached = CacheManager.get<Record<string, InstalledPluginInfo>>(
+      "app",
+      "installedPluginsInfo",
+    );
+    if (cached) {
+      return cached;
+    }
     const res: any = await execCommand("sf plugins --json", {
-      output: true,
+      output: false,
       fail: false,
-      cacheSection: "app",
-      cacheExpiration: 1000 * 60 * 5, // 5 minutes
     });
-    return parsePluginsJson((res?.stdout || "").toString());
+    // execCommand returns the parsed JSON payload for `--json` commands; the
+    // stdout string is only present on the error path
+    const pluginsInfo =
+      typeof res?.stdout === "string" && res.stdout
+        ? parsePluginsJson(res.stdout)
+        : parsePluginsData(res);
+    if (Object.keys(pluginsInfo).length > 0) {
+      await CacheManager.set(
+        "app",
+        "installedPluginsInfo",
+        pluginsInfo,
+        1000 * 60 * 5, // 5 minutes
+      );
+    }
+    return pluginsInfo;
   } catch (e: any) {
     Logger.log("Unable to list installed plugins as JSON: " + e?.message);
     return {};
@@ -576,6 +600,40 @@ export async function execSfdxJsonWithProgress(
 }
 /* jscpd:ignore-end */
 
+// Commands like `sf plugins --json` return multi-MB payloads: dumping them
+// line by line in the output channel freezes the extension host (each line is
+// an RPC to the renderer), so displayed output is capped.
+const MAX_LOGGED_OUTPUT_CHARS = 100_000;
+function truncateLoggedOutput(output: string, command: string): string {
+  if (output.length <= MAX_LOGGED_OUTPUT_CHARS) {
+    return output;
+  }
+  return (
+    output.slice(0, MAX_LOGGED_OUTPUT_CHARS) +
+    `\n[vscode-sfdx-hardis] ... output truncated in this log (${output.length} characters total for command "${command}")`
+  );
+}
+
+// globalState (backing CacheManager) is serialized synchronously on every
+// update: caching a multi-MB command result stalls the extension host and
+// triggers the VS Code "large extension state detected" warning. Oversized
+// results are simply not cached; callers must cache a trimmed value instead.
+const MAX_CACHED_RESULT_CHARS = 500_000;
+function isCacheableCommandResult(command: string, value: any): boolean {
+  try {
+    const size = JSON.stringify(value)?.length ?? 0;
+    if (size > MAX_CACHED_RESULT_CHARS) {
+      Logger.log(
+        `[vscode-sfdx-hardis][WARNING] Result of "${command}" is too large to be cached (${size} characters): cache a trimmed value instead`,
+      );
+      return false;
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 // Execute command
 export async function execCommand(
   command: string,
@@ -679,7 +737,7 @@ export async function execCommand(
   }
   // Display output if requested, for better user understanding of the logs
   if (options.output || options.debug) {
-    Logger.log(commandResult.stdout.toString());
+    Logger.log(truncateLoggedOutput(commandResult.stdout.toString(), command));
   }
   // Return status 0 if not --json
   if (!command.includes("--json")) {
@@ -691,7 +749,8 @@ export async function execCommand(
     if (
       cacheSection &&
       typeof cacheExpiration === "number" &&
-      !CacheManager.get(cacheSection, command)
+      !CacheManager.get(cacheSection, command) &&
+      isCacheableCommandResult(command, resultObj)
     ) {
       CacheManager.set(cacheSection, command, resultObj, cacheExpiration);
     }
@@ -710,7 +769,11 @@ export async function execCommand(
         "[sfdx-hardis][WARNING] stderr: " + c.yellow(commandResult.stderr),
       );
     }
-    if (cacheSection && typeof cacheExpiration === "number") {
+    if (
+      cacheSection &&
+      typeof cacheExpiration === "number" &&
+      isCacheableCommandResult(command, parsedResult)
+    ) {
       CacheManager.set(cacheSection, command, parsedResult, cacheExpiration);
     }
     return parsedResult;

--- a/src/utils/cache-manager.ts
+++ b/src/utils/cache-manager.ts
@@ -1,19 +1,39 @@
 import * as vscode from "vscode";
+import * as fs from "fs";
+import * as path from "path";
+import * as crypto from "crypto";
 import { Logger } from "../logger";
 
 interface CacheEntry<T> {
-  value: T;
+  value?: T;
+  // Set when the value is stored in a file instead of globalState (large values)
+  largeValueFile?: string;
   expiresAt: number;
 }
 
 export type CacheSection = "app" | "project" | "orgs";
 
+// globalState is serialized synchronously on every update, so large values
+// must not live there: above this size they are written to a file in the
+// extension's globalStorage folder, and only the file name + expiration are
+// kept in globalState.
+const LARGE_VALUE_THRESHOLD_CHARS = 100_000;
+// Absolute cap: a value this big is a design smell, cache a trimmed value instead
+const MAX_VALUE_CHARS = 20_000_000;
+
 export class CacheManager {
   private static store: vscode.Memento;
+  private static largeValueDir: string | null = null;
   private static KEYS_INDEX = "__cacheKeys"; // track stored keys safely
+  // Avoids re-reading/re-parsing a large value file on every get
+  private static largeValueMemo: Map<string, unknown> = new Map();
 
-  static init(store: vscode.Memento) {
+  static init(store: vscode.Memento, storageDirPath?: string) {
     this.store = store;
+    this.largeValueMemo = new Map();
+    this.largeValueDir = storageDirPath
+      ? path.join(storageDirPath, "large-cache")
+      : null;
     if (!this.store.get<string[]>(this.KEYS_INDEX)) {
       this.store.update(this.KEYS_INDEX, []);
     }
@@ -31,6 +51,20 @@ export class CacheManager {
     }
   }
 
+  private static largeValueFilePath(fileName: string): string {
+    return path.join(this.largeValueDir || "", fileName);
+  }
+
+  private static removeLargeValueFile(entry: CacheEntry<unknown>) {
+    if (entry?.largeValueFile && this.largeValueDir) {
+      try {
+        fs.unlinkSync(this.largeValueFilePath(entry.largeValueFile));
+      } catch {
+        // Already removed (temp cleanup, manual delete): nothing to do
+      }
+    }
+  }
+
   static async set<T>(
     section: CacheSection,
     key: string,
@@ -39,10 +73,49 @@ export class CacheManager {
   ): Promise<void> {
     const fullKey = this.makeKey(section, key);
     const expiresAt = Date.now() + ttlMs;
-    const entry: CacheEntry<T> = {
-      value,
-      expiresAt: expiresAt,
-    };
+    this.largeValueMemo.delete(fullKey);
+    // A large value previously stored for this key must not leak on overwrite
+    const previousEntry = this.store.get<CacheEntry<unknown>>(fullKey);
+    if (previousEntry?.largeValueFile) {
+      this.removeLargeValueFile(previousEntry);
+    }
+    let serialized: string;
+    try {
+      serialized = JSON.stringify(value) ?? "";
+    } catch {
+      Logger.log(
+        `[vscode-sfdx-hardis][WARNING] Value for cache key ${fullKey} is not serializable: not cached`,
+      );
+      return;
+    }
+    if (serialized.length > MAX_VALUE_CHARS) {
+      Logger.log(
+        `[vscode-sfdx-hardis][WARNING] Value for cache key ${fullKey} is too large to be cached (${serialized.length} characters): cache a trimmed value instead`,
+      );
+      return;
+    }
+    let entry: CacheEntry<T>;
+    if (serialized.length > LARGE_VALUE_THRESHOLD_CHARS && this.largeValueDir) {
+      // Large value: store it in a file, keep only its name in globalState
+      const fileName =
+        crypto.createHash("md5").update(fullKey).digest("hex") + ".json";
+      try {
+        fs.mkdirSync(this.largeValueDir, { recursive: true });
+        fs.writeFileSync(this.largeValueFilePath(fileName), serialized, "utf8");
+      } catch (e: any) {
+        Logger.log(
+          `[vscode-sfdx-hardis][WARNING] Unable to write large cache file for ${fullKey}: ${e?.message}`,
+        );
+        return;
+      }
+      entry = { largeValueFile: fileName, expiresAt: expiresAt };
+      this.largeValueMemo.set(fullKey, value);
+      Logger.logPerf(
+        `Cache value for ${fullKey} stored in file ${fileName} (${serialized.length} characters)`,
+      );
+    } else {
+      entry = { value, expiresAt: expiresAt };
+    }
     await this.store.update(fullKey, entry);
     await this.trackKey(fullKey);
     const expiresInDaysHoursMinutes = this.buildHumanExpiry(expiresAt);
@@ -62,13 +135,33 @@ export class CacheManager {
       this.delete(section, key); // auto cleanup expired
       return undefined;
     }
+    let value: T | undefined = entry.value;
+    if (entry.largeValueFile) {
+      if (this.largeValueMemo.has(fullKey)) {
+        value = this.largeValueMemo.get(fullKey) as T;
+      } else {
+        try {
+          value = JSON.parse(
+            fs.readFileSync(
+              this.largeValueFilePath(entry.largeValueFile),
+              "utf8",
+            ),
+          );
+          this.largeValueMemo.set(fullKey, value);
+        } catch {
+          // File removed or unreadable: behave as a cache miss
+          this.delete(section, key);
+          return undefined;
+        }
+      }
+    }
     // Hot path: keys are already tracked by set(); logging goes through
     // logPerf so cache hits cost nothing when the debug setting is off
     const expiresInDaysHoursMinutes = this.buildHumanExpiry(entry.expiresAt);
     Logger.logPerf(
       `Cache hit for ${section}:${key} (expires in ${expiresInDaysHoursMinutes})`,
     );
-    return entry.value;
+    return value;
   }
 
   static has(section: CacheSection, key: string): boolean {
@@ -105,6 +198,11 @@ export class CacheManager {
     }
 
     for (const k of toDelete) {
+      const entry = this.store.get<CacheEntry<unknown>>(k);
+      if (entry?.largeValueFile) {
+        this.removeLargeValueFile(entry);
+      }
+      this.largeValueMemo.delete(k);
       await this.store.update(k, undefined);
       Logger.log(`Cache deleted for key ${k}`);
     }
@@ -119,6 +217,10 @@ export class CacheManager {
       const entry = this.store.get<CacheEntry<unknown>>(k);
       if (entry && entry.expiresAt < now) {
         expiredKeys.push(k);
+        if (entry.largeValueFile) {
+          this.removeLargeValueFile(entry);
+        }
+        this.largeValueMemo.delete(k);
         await this.store.update(k, undefined);
       }
     }

--- a/src/utils/cache-manager.ts
+++ b/src/utils/cache-manager.ts
@@ -73,12 +73,10 @@ export class CacheManager {
   ): Promise<void> {
     const fullKey = this.makeKey(section, key);
     const expiresAt = Date.now() + ttlMs;
-    this.largeValueMemo.delete(fullKey);
-    // A large value previously stored for this key must not leak on overwrite
+    // Any early return below must leave the previously stored entry (and its
+    // file) fully intact: a rejected NEW value must never destroy a still
+    // valid OLD one, so nothing is deleted before the new entry is committed
     const previousEntry = this.store.get<CacheEntry<unknown>>(fullKey);
-    if (previousEntry?.largeValueFile) {
-      this.removeLargeValueFile(previousEntry);
-    }
     let serialized: string;
     try {
       serialized = JSON.stringify(value) ?? "";
@@ -96,12 +94,18 @@ export class CacheManager {
     }
     let entry: CacheEntry<T>;
     if (serialized.length > LARGE_VALUE_THRESHOLD_CHARS && this.largeValueDir) {
-      // Large value: store it in a file, keep only its name in globalState
+      // Large value: store it in a file, keep only its name in globalState.
+      // Written to a temp file then renamed: the deterministic name means
+      // another VS Code window can be reading the previous version of this
+      // very file, and it must never observe a partial write
       const fileName =
         crypto.createHash("md5").update(fullKey).digest("hex") + ".json";
+      const finalPath = this.largeValueFilePath(fileName);
       try {
         fs.mkdirSync(this.largeValueDir, { recursive: true });
-        fs.writeFileSync(this.largeValueFilePath(fileName), serialized, "utf8");
+        const tmpPath = `${finalPath}.${process.pid}.tmp`;
+        fs.writeFileSync(tmpPath, serialized, "utf8");
+        fs.renameSync(tmpPath, finalPath);
       } catch (e: any) {
         Logger.log(
           `[vscode-sfdx-hardis][WARNING] Unable to write large cache file for ${fullKey}: ${e?.message}`,
@@ -115,8 +119,15 @@ export class CacheManager {
       );
     } else {
       entry = { value, expiresAt: expiresAt };
+      this.largeValueMemo.delete(fullKey);
     }
     await this.store.update(fullKey, entry);
+    // Only now that the new entry is committed: a file the entry no longer
+    // references (large -> small transition) must not leak on disk. The
+    // large -> large case overwrote the same deterministic file name in place.
+    if (previousEntry?.largeValueFile && !entry.largeValueFile) {
+      this.removeLargeValueFile(previousEntry);
+    }
     await this.trackKey(fullKey);
     const expiresInDaysHoursMinutes = this.buildHumanExpiry(expiresAt);
     Logger.logPerf(
@@ -148,9 +159,17 @@ export class CacheManager {
             ),
           );
           this.largeValueMemo.set(fullKey, value);
-        } catch {
-          // File removed or unreadable: behave as a cache miss
-          this.delete(section, key);
+        } catch (e: any) {
+          // A missing or corrupted file is a real miss: drop the entry. A
+          // transient read error (EBUSY/EACCES: antivirus scan, file locked by
+          // another VS Code window) must NOT delete the shared entry and file
+          if (e?.code === "ENOENT" || e instanceof SyntaxError) {
+            this.delete(section, key);
+          } else {
+            Logger.log(
+              `[vscode-sfdx-hardis][WARNING] Unable to read large cache file for ${fullKey}: ${e?.message}`,
+            );
+          }
           return undefined;
         }
       }

--- a/src/utils/pluginsVersionUtils.ts
+++ b/src/utils/pluginsVersionUtils.ts
@@ -18,6 +18,8 @@ export type PluginInstallKind = "localdev" | "preview" | "standard" | "missing";
 
 export interface InstalledPluginInfo {
   name: string;
+  // npm alias when it differs from the name (ex: "@salesforce/plugin-packaging")
+  alias?: string | null;
   version: string;
   // "user" | "link" | "core"
   type?: string;
@@ -34,10 +36,9 @@ export interface InstalledPluginInfo {
 export function parsePluginsJson(
   stdout: string,
 ): Record<string, InstalledPluginInfo> {
-  const result: Record<string, InstalledPluginInfo> = {};
   const cleanStdout = stripAnsiCodes(stdout || "").trim();
   if (!cleanStdout) {
-    return result;
+    return {};
   }
   let parsed: any;
   try {
@@ -46,14 +47,28 @@ export function parsePluginsJson(
     // Output can contain warning lines before the JSON payload
     const firstBracket = cleanStdout.search(/[[{]/);
     if (firstBracket === -1) {
-      return result;
+      return {};
     }
     try {
       parsed = JSON.parse(cleanStdout.substring(firstBracket));
     } catch {
-      return result;
+      return {};
     }
   }
+  return parsePluginsData(parsed);
+}
+
+/**
+ * Same as parsePluginsJson, from an already parsed `sf plugins --json` payload
+ * (execCommand returns the parsed JSON for `--json` commands, not the stdout).
+ * Only the few fields the extension uses are kept: the raw payload embeds the
+ * whole oclif manifest of every plugin (several MB), which must never be
+ * stored or logged as-is.
+ */
+export function parsePluginsData(
+  parsed: any,
+): Record<string, InstalledPluginInfo> {
+  const result: Record<string, InstalledPluginInfo> = {};
   const plugins = Array.isArray(parsed) ? parsed : parsed?.result;
   if (!Array.isArray(plugins)) {
     return result;
@@ -62,6 +77,7 @@ export function parsePluginsJson(
     if (plugin && typeof plugin.name === "string") {
       result[plugin.name] = {
         name: plugin.name,
+        alias: plugin.alias ?? null,
         version: plugin.version || "",
         type: plugin.type,
         tag: plugin.tag ?? null,

--- a/src/utils/setupUtils.ts
+++ b/src/utils/setupUtils.ts
@@ -755,10 +755,18 @@ export class SetupHelper {
     name: string,
     action: () => Promise<void>,
     command?: string,
-  ): Promise<{ success: boolean; message?: string; command?: string }> {
+  ): Promise<{
+    success: boolean;
+    message?: string;
+    command?: string;
+    reason?: string;
+  }> {
     if (this.hasUpdatesInProgress()) {
       return {
         success: false,
+        // Machine-readable marker: the setup LWC uses it to know the install
+        // was never attempted (vs actually failed), independently of locale
+        reason: "alreadyRunning",
         message: t("installInProgress"),
         ...(command !== undefined ? { command } : {}),
       };
@@ -796,7 +804,21 @@ export class SetupHelper {
     const recommended =
       RECOMMENDED_SFDX_CLI_VERSION ||
       (await getNpmLatestVersion("@salesforce/cli").catch(() => null));
-    const command = buildSfCliUpgradeCommand(sfdxPath, recommended);
+    // A legacy sfdx-cli install cannot be upgraded in place: it must be
+    // uninstalled before installing @salesforce/cli, otherwise both global
+    // binaries coexist and `sf` keeps resolving to the deprecated one
+    // (same command as the one checkSfCli() advertises for this case)
+    const versionRes: any = await execCommand("sf --version", {
+      fail: false,
+      output: false,
+      spinner: false,
+    });
+    const isLegacySfdxCli = /sfdx-cli\//.test(
+      (versionRes?.stdout || "").toString(),
+    );
+    const command = isLegacySfdxCli
+      ? "npm uninstall sfdx-cli --global && npm install @salesforce/cli --global"
+      : buildSfCliUpgradeCommand(sfdxPath, recommended);
     return this.runUpdateOperation(
       "sf",
       async () => {

--- a/src/utils/sfdx-hardis-config-utils.ts
+++ b/src/utils/sfdx-hardis-config-utils.ts
@@ -5,7 +5,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { getText } from "./httpUtils";
 import { t } from "../i18n/i18n";
-import { execSfdxJson } from "../utils";
+import { execSfdxJson, getInstalledPluginsInfo } from "../utils";
 import { Logger } from "../logger";
 
 /** A single command entry inside a custom menu */
@@ -363,21 +363,13 @@ const KNOWN_PLUGINS = [
 
 /**
  * Returns the list of non-core installed plugin names (type === "user" or "link").
- * Uses the "app" cache section with a 1-day TTL.
+ * Reuses the trimmed plugin infos cached by getInstalledPluginsInfo(), so the
+ * multi-MB raw `sf plugins --json` payload is never stored in globalState.
  */
 async function listNonCorePluginNames(): Promise<string[]> {
-  const result = await execSfdxJson("sf plugins --json", {
-    fail: false,
-    output: false,
-    cacheSection: "app",
-    cacheExpiration: 1000 * 60 * 60 * 24, // 1 day
-  });
-  const plugins: any[] = result?.result ?? result ?? [];
-  if (!Array.isArray(plugins)) {
-    return [];
-  }
-  return plugins
-    .filter((p: any) => {
+  const pluginsInfo = await getInstalledPluginsInfo();
+  return Object.values(pluginsInfo)
+    .filter((p) => {
       const pType = p.type || "";
       if (pType !== "user" && pType !== "link") {
         return false;
@@ -388,7 +380,7 @@ async function listNonCorePluginNames(): Promise<string[]> {
         !KNOWN_PLUGINS.includes(name)
       );
     })
-    .map((p: any) => p.alias || p.name);
+    .map((p) => p.alias || p.name);
 }
 
 /**

--- a/src/webviews/lwc-ui/modules/s/setup/setup.js
+++ b/src/webviews/lwc-ui/modules/s/setup/setup.js
@@ -50,6 +50,9 @@ export default class Setup extends SharedMixin(LightningElement) {
       // Render the static list first (no checking yet) so the UI paints quickly
       this._autoUpdateDependencies =
         data && data.autoUpdateDependencies === true;
+      // Full refresh: give auto-update a fresh chance on every re-check cycle
+      // (a previous failure may have been fixed outside the panel since)
+      this._autoInstallAttemptedIds = new Set();
       this.checks = data.checks.map((c) => ({
         ...c,
         explanation: c.explanation || "",
@@ -122,6 +125,11 @@ export default class Setup extends SharedMixin(LightningElement) {
     // Receive install result
     else if (type === "installResult") {
       const { id, res } = data || {};
+      // The install was never attempted (another update was already running):
+      // let auto-update retry it instead of burning its one attempt
+      if (res && res.reason === "alreadyRunning") {
+        this._autoInstallAttemptedIds.delete(id);
+      }
       // After install, re-run the single check to refresh its status
       this._startCheck(id);
     }
@@ -327,10 +335,12 @@ export default class Setup extends SharedMixin(LightningElement) {
       }
     }
 
-    // Auto-update tries each dependency at most once per panel session: a
+    // Auto-update tries each dependency at most once per re-check cycle: a
     // failing install re-checks into the same pending status, and retrying it
-    // automatically would loop forever (the user can still retry manually)
-    const autoInstallCandidates = this.listInstallCandidates().filter(
+    // automatically would loop forever (the user can still retry manually).
+    // Only the exact filtered list is run and marked: installing unrelated
+    // errored cards, or re-running previously failed ones, is manual-only
+    const autoInstallCandidates = this.listAutoInstallCandidates().filter(
       (c) => !this._autoInstallAttemptedIds.has(c.id),
     );
     if (
@@ -342,10 +352,10 @@ export default class Setup extends SharedMixin(LightningElement) {
       this.hasPendingActions
     ) {
       // Automatically run pending installs if the setting is enabled, the queue is not already running, and there are pending actions
-      this.listInstallCandidates().forEach((c) =>
+      autoInstallCandidates.forEach((c) =>
         this._autoInstallAttemptedIds.add(c.id),
       );
-      this.runPendingInstalls();
+      this.runPendingInstalls(autoInstallCandidates);
     }
 
     // Ensure button labels/disabled state reflect the new summary/installQueue states
@@ -555,9 +565,26 @@ export default class Setup extends SharedMixin(LightningElement) {
     return installCandidates;
   }
 
-  // Run the install queue for all items that need install/upgrade and are installable
-  async runPendingInstalls() {
-    const installCandidates = this.listInstallCandidates();
+  // Candidates auto-update is allowed to install unattended: dependencies that
+  // genuinely need an install (missing, outdated, or a mandatory upgrade).
+  // Other error cards (transient check failures, e.g. npm registry unreachable)
+  // are left alone: reinstalling cannot fix them
+  listAutoInstallCandidates() {
+    return this.listInstallCandidates().filter(
+      (c) =>
+        c.status === "missing" ||
+        c.status === "outdated" ||
+        (c.status === "error" && c.upgradeAvailable === true),
+    );
+  }
+
+  // Run the install queue for all items that need install/upgrade and are
+  // installable. `candidates` restricts the queue to an explicit list (used by
+  // auto-update); anything else (the button click event) runs the full list
+  async runPendingInstalls(candidates = null) {
+    const installCandidates = Array.isArray(candidates)
+      ? candidates
+      : this.listInstallCandidates();
     if (installCandidates.length === 0) {
       const manualInstallCandidates = this.checks.filter((c) => {
         if (

--- a/src/webviews/lwc-ui/modules/s/setup/setup.js
+++ b/src/webviews/lwc-ui/modules/s/setup/setup.js
@@ -404,9 +404,18 @@ export default class Setup extends SharedMixin(LightningElement) {
         buttonTint = "hardis-btn-tinted-blue";
         buttonAction = c.installable ? "install" : "instructions";
       } else if (status === "error") {
-        buttonLabel = this.t("fixInstructions");
-        buttonTint = "hardis-btn-tinted-blue";
-        buttonAction = "instructions";
+        // A mandatory upgrade (ex: sfdx-hardis older than the minimal version)
+        // is still an upgrade: run the install command instead of sending the
+        // user to generic fix instructions
+        if (c.upgradeAvailable === true && c.installable) {
+          buttonLabel = this.t("upgradeLabel");
+          buttonTint = "hardis-btn-tinted-amber";
+          buttonAction = "install";
+        } else {
+          buttonLabel = this.t("fixInstructions");
+          buttonTint = "hardis-btn-tinted-blue";
+          buttonAction = "instructions";
+        }
       }
       const buttonClass = buttonTint;
 
@@ -493,7 +502,12 @@ export default class Setup extends SharedMixin(LightningElement) {
       this.checks &&
       this.checks.some((c) => {
         const status = c.status || (c.installed ? "ok" : "missing");
-        const needs = status === "missing" || status === "outdated";
+        // "error" with an upgrade available is a mandatory upgrade
+        // (ex: sfdx-hardis older than the minimal version)
+        const needs =
+          status === "missing" ||
+          status === "outdated" ||
+          (status === "error" && c.upgradeAvailable === true);
         if (!needs) return false;
         // Exclude manual-only installs
         if (c.id === "node" || c.id === "git") return false;

--- a/src/webviews/lwc-ui/modules/s/setup/setup.js
+++ b/src/webviews/lwc-ui/modules/s/setup/setup.js
@@ -366,7 +366,13 @@ export default class Setup extends SharedMixin(LightningElement) {
             state = "error";
             break;
           case "error":
-            statusIcon = "utility:ban";
+            // A mandatory upgrade is not a broken dependency: show the same
+            // warning icon as an optional upgrade, on the red (required) accent
+            if (c.upgradeAvailable === true && c.installable) {
+              statusIcon = "utility:warning";
+            } else {
+              statusIcon = "utility:ban";
+            }
             state = "error";
         }
       }

--- a/src/webviews/lwc-ui/modules/s/setup/setup.js
+++ b/src/webviews/lwc-ui/modules/s/setup/setup.js
@@ -327,15 +327,24 @@ export default class Setup extends SharedMixin(LightningElement) {
       }
     }
 
+    // Auto-update tries each dependency at most once per panel session: a
+    // failing install re-checks into the same pending status, and retrying it
+    // automatically would loop forever (the user can still retry manually)
+    const autoInstallCandidates = this.listInstallCandidates().filter(
+      (c) => !this._autoInstallAttemptedIds.has(c.id),
+    );
     if (
       this._autoUpdateDependencies &&
-      this.listInstallCandidates().length > 0 &&
+      autoInstallCandidates.length > 0 &&
       !anyChecking &&
       !this.installQueueRunning &&
       !this._summaryChecking &&
       this.hasPendingActions
     ) {
       // Automatically run pending installs if the setting is enabled, the queue is not already running, and there are pending actions
+      this.listInstallCandidates().forEach((c) =>
+        this._autoInstallAttemptedIds.add(c.id),
+      );
       this.runPendingInstalls();
     }
 
@@ -483,6 +492,10 @@ export default class Setup extends SharedMixin(LightningElement) {
 
   // Flag indicating install queue is running to prevent re-entrancy
   _installQueueRunning = false;
+
+  // Dependencies already auto-installed once in this panel session, so a
+  // failing install is not retried in a loop by the auto-update setting
+  _autoInstallAttemptedIds = new Set();
 
   // Expose whether the install queue is currently running
   get installQueueRunning() {


### PR DESCRIPTION
## Problem

When the installed sfdx-hardis plugin is older than the minimal required version (e.g. 7.23.0 vs required 8.0.0), the Install Dependencies panel showed a **Fix Instructions** button whose only effect was a modal leading to https://github.com/hardisgroupcom/sfdx-hardis — instead of simply offering to upgrade the plugin.

## Root cause

`setupUtils.ts` returns `status: "error"` for this mandatory-upgrade case (with `upgradeAvailable: true` and a working `installCommand`), but the setup LWC mapped **every** `error` card to the Fix Instructions button that opens `helpUrl`.

## Fix

- In the setup LWC, an `error` card that is installable and has an upgrade available now shows an **Upgrade** button (amber tint, same as `outdated`) that runs the install command directly (`sf plugins install sfdx-hardis@latest`)
- `hasPendingActions` now also counts these cards, so **Auto-update dependencies** and **Run pending installs** handle the mandatory upgrade as well
- Genuine error cards (check failed, no upgrade path) keep the Fix Instructions button

Also applies to the pre-release alpha/beta upgrade cases, which use the same `error` + `upgradeAvailable` shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)