### PR TITLE
feat: expert user mode setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- New setting **Expert user mode**: sfdx-hardis commands skip their confirmation questions. **Save / Publish my User Story** no longer asks if your metadata is committed, which cleanings to apply or if you want to push, and it opens the Pull Request page at the end. Requires sfdx-hardis v8.4.0 or later.
+
 ## [8.3.0] 2026-08-26
 
 - For sfdx-hardis contributors using `sf plugins link`: commands started by the extension now run the linked plugin from its compiled `lib` folder instead of re-transpiling its TypeScript sources at every launch, saving about 3 seconds per command (measured on **New User Story**: first prompt after 8 seconds instead of 11)

--- a/package.json
+++ b/package.json
@@ -70,6 +70,12 @@
           ],
           "description": "When userInput is set to ui-lwc, defines if commands are executed in background or in a terminal"
         },
+        "vsCodeSfdxHardis.userModeExpert": {
+          "type": "boolean",
+          "default": false,
+          "title": "Expert user mode",
+          "description": "Skip the confirmation questions of sfdx-hardis commands, for users who already know the answers. For example, hardis:work:save no longer asks if your metadata is committed, which cleanings to apply or if you want to push, and it opens the Pull Request page at the end. Sends SFDX_HARDIS_EXPERT_MODE=true to sfdx-hardis commands."
+        },
         "vsCodeSfdxHardis.customCommandsConfiguration": {
           "type": "string",
           "description": "Absolute path or URL to a .sfdx-hardis.yml file that contains custom commands for the menu\nSee https://github.com/hardisgroupcom/vscode-sfdx-hardis#custom-commands"

--- a/src/command-runner.ts
+++ b/src/command-runner.ts
@@ -534,6 +534,14 @@ export class CommandRunner {
     if (langSetting && langSetting !== "auto" && !extraEnv?.SFDX_HARDIS_LANG) {
       spawnOptions.env.SFDX_HARDIS_LANG = langSetting;
     }
+    // Expert mode: sfdx-hardis commands skip their confirmation questions
+    if (
+      config.get("userModeExpert") === true &&
+      !extraEnv?.SFDX_HARDIS_EXPERT_MODE &&
+      preprocessedCommand.trimStart().startsWith("sf hardis")
+    ) {
+      spawnOptions.env.SFDX_HARDIS_EXPERT_MODE = "true";
+    }
     if (config.get("disableTlsRejectUnauthorized") === true) {
       spawnOptions.env = {
         ...spawnOptions.env,
@@ -1054,6 +1062,14 @@ export class CommandRunner {
       cmd.trimStart().startsWith("sf hardis")
     ) {
       cmd = `SFDX_HARDIS_LANG=${langSetting} ${cmd}`;
+    }
+    // Expert mode: sfdx-hardis commands skip their confirmation questions
+    if (
+      config.get("userModeExpert") === true &&
+      !extraEnv?.SFDX_HARDIS_EXPERT_MODE &&
+      registeredCmd.trimStart().startsWith("sf hardis")
+    ) {
+      cmd = `SFDX_HARDIS_EXPERT_MODE=true ${cmd}`;
     }
     if (extraEnv && typeof extraEnv === "object") {
       // Filter out secret env vars — they must never appear in the terminal

--- a/src/utils/extensionConfigUtils.ts
+++ b/src/utils/extensionConfigUtils.ts
@@ -13,6 +13,7 @@ export const sectionDefs = [
     keys: [
       "vsCodeSfdxHardis.userInput",
       "vsCodeSfdxHardis.userInputCommandLineIfLWC",
+      "vsCodeSfdxHardis.userModeExpert",
       "vsCodeSfdxHardis.showCommandsDetails",
       "vsCodeSfdxHardis.customCommandsConfiguration",
     ],


### PR DESCRIPTION
Extension side of https://github.com/orgs/hardisgroupcom/discussions/2119.
CLI side: hardisgroupcom/sfdx-hardis#2121

## What

New setting **Expert user mode** (`vsCodeSfdxHardis.userModeExpert`, default `false`).

When checked, every `sf hardis` command started by the extension receives `SFDX_HARDIS_EXPERT_MODE=true` and skips its confirmation questions. For **Save / Publish my User Story**, that means no more questions about the metadata being committed, which cleanings to apply or whether to push, and the Pull Request page is opened at the end.

An env var rather than a per-command flag, so other sfdx-hardis commands can adopt the behavior without a change here.

## Changes

- New setting declared in `package.json` and listed in the **User input** section of the Setup panel
- `CommandRunner` sends the env var in both execution modes (background spawn env and terminal env prefix), following the existing `SFDX_HARDIS_LANG` pattern

Requires sfdx-hardis v8.4.0 or later.
