### PR TITLE
fix: no git provider sign-in prompt when the project has no sfdx-hardis pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- The extension no longer asks you to sign in again to your git provider (Azure DevOps, GitHub, GitLab, Bitbucket, Gitea) when the project does not define an sfdx-hardis pipeline: without branch configuration files in `config/branches/`, there is nothing the git provider connection would be used for, so the authentication failure is only written to the logs
+
 ## [8.3.2] 2026-09-02
 
 - **Run Local HTML Doc Pages** now previews the documentation with Zensical, the successor of mkdocs-material used by sfdx-hardis since v8.4.0

--- a/src/utils/gitProviders/gitProviderAzure.ts
+++ b/src/utils/gitProviders/gitProviderAzure.ts
@@ -210,12 +210,13 @@ export class GitProviderAzure extends GitProvider {
       );
       this.gitApi = null;
       this.isActive = false;
-      showAuthFailureGuidance({
+      await showAuthFailureGuidance({
         providerName: "Azure DevOps",
         guidance: t("azureDevOpsAuthInfo"),
         retry: () => this.reauthenticateAndRefresh(),
         docUrl:
           "https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate",
+        onlyIfPipelineConfigured: true,
       });
     }
   }

--- a/src/utils/gitProviders/gitProviderBitbucket.ts
+++ b/src/utils/gitProviders/gitProviderBitbucket.ts
@@ -213,12 +213,13 @@ export class GitProviderBitbucket extends GitProvider {
       } catch (err) {
         Logger.log(`Bitbucket repository access check failed: ${String(err)}`);
         this.isActive = false;
-        showAuthFailureGuidance({
+        await showAuthFailureGuidance({
           providerName: "Bitbucket",
           guidance: t("bitbucketAuthInfo"),
           retry: () => this.reauthenticateAndRefresh(),
           docUrl:
             "https://support.atlassian.com/bitbucket-cloud/docs/access-tokens/",
+          onlyIfPipelineConfigured: true,
         });
       }
     } else {

--- a/src/utils/gitProviders/gitProviderGitHub.ts
+++ b/src/utils/gitProviders/gitProviderGitHub.ts
@@ -196,12 +196,13 @@ export class GitProviderGitHub extends GitProvider {
       this.isActive = false;
       const isEnterprise =
         this.repoInfo?.host && this.repoInfo.host !== "github.com";
-      showAuthFailureGuidance({
+      await showAuthFailureGuidance({
         providerName: isEnterprise ? "GitHub Enterprise" : "GitHub",
         guidance: t("githubEnterpriseAuthInfo"),
         retry: () => this.reauthenticateAndRefresh(),
         docUrl:
           "https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens",
+        onlyIfPipelineConfigured: true,
       });
     }
   }

--- a/src/utils/gitProviders/gitProviderGitea.ts
+++ b/src/utils/gitProviders/gitProviderGitea.ts
@@ -101,11 +101,12 @@ export class GitProviderGitea extends GitProviderGitHub {
     } catch {
       this.gitHubClient = null;
       this.isActive = false;
-      showAuthFailureGuidance({
+      await showAuthFailureGuidance({
         providerName: "Gitea",
         guidance: t("giteaAuthInfo"),
         retry: () => this.reauthenticateAndRefresh(),
         docUrl: "https://docs.gitea.com/development/api-usage",
+        onlyIfPipelineConfigured: true,
       });
     }
   }

--- a/src/utils/gitProviders/gitProviderGitlab.ts
+++ b/src/utils/gitProviders/gitProviderGitlab.ts
@@ -147,12 +147,13 @@ export class GitProviderGitlab extends GitProvider {
         );
       }
       if (!this.isActive) {
-        showAuthFailureGuidance({
+        await showAuthFailureGuidance({
           providerName: "GitLab",
           guidance: t("gitlabAuthInfo"),
           retry: () => this.reauthenticateAndRefresh(),
           docUrl:
             "https://docs.gitlab.com/user/profile/personal_access_tokens/",
+          onlyIfPipelineConfigured: true,
         });
       }
     }

--- a/src/utils/pipeline/sfdxHardisConfig.ts
+++ b/src/utils/pipeline/sfdxHardisConfig.ts
@@ -184,6 +184,35 @@ export async function setInConfigFile(
   );
 }
 
+/**
+ * Tells whether the opened project defines an sfdx-hardis CI/CD pipeline, i.e.
+ * whether it declares major branches in config/branches/.sfdx-hardis.<branch>.yml .
+ *
+ * Without those files there is no major org, no DevOps Pipeline and none of the
+ * features that need an authenticated git provider, so the extension must not
+ * bother the user with git provider authentication.
+ *
+ * Not cached on purpose: it is a single directory read, and the answer changes
+ * as soon as the user configures the pipeline.
+ */
+export async function isPipelineConfigured(): Promise<boolean> {
+  const workspaceRoot = getWorkspaceRoot();
+  if (!workspaceRoot) {
+    return false;
+  }
+  try {
+    const branchConfigFiles = await fs.promises.readdir(
+      path.join(workspaceRoot, "config", "branches"),
+    );
+    return branchConfigFiles.some((file) =>
+      /^\.sfdx-hardis\..+\.ya?ml$/.test(file),
+    );
+  } catch {
+    // No config/branches folder at all: the pipeline is not configured
+    return false;
+  }
+}
+
 let isGitRepoCache: boolean | null = null;
 let isGitRepoInFlight: Promise<boolean> | null = null;
 export async function isGitRepo(): Promise<boolean> {

--- a/src/utils/providerCredentials.ts
+++ b/src/utils/providerCredentials.ts
@@ -3,7 +3,7 @@ import { GitProvider } from "./gitProviders/gitProvider";
 import { CreateTokenOption } from "./gitProviders/types";
 import { TicketProvider } from "./ticketProviders/ticketProvider";
 import { SecretsManager } from "./secretsManager";
-import { getConfig } from "./pipeline/sfdxHardisConfig";
+import { getConfig, isPipelineConfigured } from "./pipeline/sfdxHardisConfig";
 import { Logger } from "../logger";
 import { t } from "../i18n/i18n";
 
@@ -92,14 +92,30 @@ export async function promptForToken(options: {
  * provider icon (token-type choice, token creation page with the right scopes, token
  * entry) — unifying the failure path with the proactive one. Otherwise (e.g. ticketing
  * providers) it falls back to a "Create Token" button opening `createTokenUrl`.
+ *
+ * `onlyIfPipelineConfigured` keeps the message for the projects that can actually use
+ * the provider: git provider authentication only powers pipeline features (DevOps
+ * Pipeline, pull requests, CI jobs), so in a project without branch configuration the
+ * failure is only traced in the logs, never shown.
  */
-export function showAuthFailureGuidance(options: {
+export async function showAuthFailureGuidance(options: {
   providerName: string;
   guidance: string;
   createTokenUrl?: string;
   docUrl: string;
   retry?: () => Promise<void> | void;
-}): void {
+  onlyIfPipelineConfigured?: boolean;
+}): Promise<void> {
+  if (
+    options.onlyIfPipelineConfigured === true &&
+    !(await isPipelineConfigured())
+  ) {
+    Logger.log(
+      `${options.providerName} authentication failed, but this project does not define an sfdx-hardis pipeline: not prompting to sign in again`,
+    );
+    return;
+  }
+
   const buttons: string[] = [];
   const urlMap: Record<string, string> = {};
 

--- a/src/utils/ticketProviders/ticketProviderJira.ts
+++ b/src/utils/ticketProviders/ticketProviderJira.ts
@@ -288,7 +288,7 @@ export class JiraProvider extends TicketProvider {
       const tokenUrl = isCloud
         ? "https://id.atlassian.com/manage-profile/security/api-tokens"
         : `${this.jiraHost}/secure/ViewProfile.jspa?selectedTab=com.atlassian.pats.pats-plugin:jira-user-personal-access-tokens`;
-      showAuthFailureGuidance({
+      await showAuthFailureGuidance({
         providerName: "Jira",
         guidance: isCloud ? t("jiraCloudAuthInfo") : t("jiraServerAuthInfo"),
         createTokenUrl: tokenUrl,


### PR DESCRIPTION
## Problem

Opening a plain Salesforce project hosted on Azure Repos (or GitHub/GitLab/Bitbucket/Gitea) could pop an unsolicited notification:

> Azure DevOps authentication failed. Requires Microsoft OAuth, or a Personal Access Token (PAT) with the Code (Read & Write), Build (Read & Execute) and Work Items (Read & Write) scopes. — **Sign in again** / **View documentation**

Git providers validate their credentials in `initialize()`, which runs as soon as a git remote is detected — regardless of what the project is. In a project without an sfdx-hardis pipeline, that connection powers nothing (no DevOps Pipeline view, no major orgs, no pull request or CI job listing), so the prompt was pure noise.

## Fix

- **`src/utils/pipeline/sfdxHardisConfig.ts`** — new `isPipelineConfigured()`: reads `config/branches/` and reports whether any `.sfdx-hardis.<branch>.yml|yaml` file declares a major branch. Uncached on purpose (a single directory read, only on the auth-failure path) so it picks up a pipeline configured later without a window reload.
- **`src/utils/providerCredentials.ts`** — `showAuthFailureGuidance()` becomes async and accepts `onlyIfPipelineConfigured`. When set and no pipeline exists, the failure is written to the logs only and no notification is shown.
- **The five git providers** (Azure DevOps, GitHub, GitLab, Bitbucket, Gitea) pass `onlyIfPipelineConfigured: true` and `await` the call.

Jira is deliberately left ungated: its provider is only instantiated when `jiraHost` is set in `.sfdx-hardis.yml`, so it is already opt-in and its failure message is always relevant. It only gains the `await` now that the function is async.

Provider initialization itself is unchanged — it stays silent, keeps filling the credentials passed to `sf hardis:*` commands, and clicking the git provider icon still offers the full sign-in flow in any project.

## Validation

- `yarn lint` — clean
- `yarn compile` — clean
- `yarn test` — 254 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9GjpCAGWVw4z6HTpAwocg
