### PR TITLE
fix: show the value of every setting in the configuration panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- **Global Pipeline Settings** and **Branch Settings** now show the value of every setting, not only the toggles
+  - Text, number and list values are displayed in full contrast instead of the pale grey that made them look like the "Not defined" placeholder, and a long value (a regular expression, a path, a URL) wraps instead of being cut off, with the complete value in its tooltip
+  - Values that select an option (test level, ticketing provider, manual actions mode, authentication mode...) are displayed as a labelled chip, like the list values
+  - The development branch is displayed as a branch chip, like the target branches
+  - Technical values (regular expressions, paths, API names) use a monospace font so every character stays readable
+  - A value that is not written in your configuration files is marked **Default**, so the value sfdx-hardis applies by default is no longer indistinguishable from a value you chose
+- **Extension Settings**: a text or number setting left empty now shows its default value in the field, instead of an empty box
+
 ## [8.3.3] 2026-09-03
 
 - The extension no longer asks you to sign in again to your git provider (Azure DevOps, GitHub, GitLab, Bitbucket, Gitea) when the project does not define an sfdx-hardis pipeline: without branch configuration files in `config/branches/`, there is nothing the git provider connection would be used for, so the authentication failure is only written to the logs

--- a/resources/global-theme.css
+++ b/resources/global-theme.css
@@ -1310,6 +1310,51 @@ lightning-helptext::part(icon) {
   margin-top: 1px;
   max-width: 62ch;
 }
+/* Read-only value of a setting. It must read as a VALUE, not as more help
+   text: the muted slds-text-color_weak it replaces was the exact color of
+   .hardis-field-help and of the "Not defined" placeholder, so a configured
+   setting looked empty. Long values (regexes, URLs, api names) wrap inside
+   the control column instead of overflowing it. */
+.hardis-field-value {
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--slds-g-color-neutral-base-10);
+  text-align: right;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+}
+/* Technical values (regex, path, api name): characters that matter stay
+   distinguishable, same monospace stack as .hardis-prop-value.mono. */
+.hardis-field-value.mono {
+  font-family: ui-monospace, "Cascadia Code", Consolas, Menlo, monospace;
+  font-size: 0.8rem;
+}
+/* Placeholder of a setting left empty. */
+.hardis-not-set,
+.hardis-field-value.hardis-not-set {
+  font-weight: 400;
+  font-style: italic;
+  color: var(--slds-g-color-neutral-base-50);
+}
+/* "Default" marker shown next to a value nobody configured, so a default is
+   never passed off as a deliberate choice. Deliberately not a chip: chips
+   carry values in these panels. */
+.hardis-field-default {
+  font-size: 0.76rem;
+  color: var(--slds-g-color-neutral-base-50);
+  text-align: right;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+}
+/* Clickable URL value: truncated to the control column, full URL in the
+   title attribute. */
+.hardis-url-link {
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: bottom;
+}
 /* Inline flex label: SLDS form label + trailing helptext icon on one line.
    Replaces the copy-pasted style="display:flex;align-items:center;gap:.25rem". */
 .hardis-label-inline {

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -364,6 +364,8 @@
   "debuggerDescription": "Salesforce Apex-Code debuggen mit integrierter Protokollanalyse und Checkpoint-Verwaltung.",
   "debuggingOptions": "Debugging-Optionen für die Erweiterung.",
   "defaultOrgLabel": "Standard-Org",
+  "defaultValueBadge": "Standardwert",
+  "defaultValueTooltip": "Nicht in der Konfiguration festgelegt: sfdx-hardis wendet diesen Standardwert an",
   "deleteDataFromOrgWithSfdmu": "Daten aus Org mit SFDMU löschen",
   "deleteDataTooltip": "Daten aus der Org mithilfe von SFDMU-Konfigurationsdateien löschen",
   "deleteLabel": "Löschen",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -364,6 +364,8 @@
   "debuggerDescription": "Debug Salesforce Apex code with integrated log analysis and checkpoint management.",
   "debuggingOptions": "Debugging options for the extension.",
   "defaultOrgLabel": "Default Org",
+  "defaultValueBadge": "Default",
+  "defaultValueTooltip": "Not set in the configuration: sfdx-hardis applies this default value",
   "deleteDataFromOrgWithSfdmu": "Delete data from org with SFDMU",
   "deleteDataTooltip": "Delete data from org using SFDMU config files",
   "deleteLabel": "Delete",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -364,6 +364,8 @@
   "debuggerDescription": "Depure el código Apex de Salesforce con análisis de logs integrado y gestión de checkpoints.",
   "debuggingOptions": "Opciones de depuración para la extensión.",
   "defaultOrgLabel": "Org predeterminada",
+  "defaultValueBadge": "Predeterminado",
+  "defaultValueTooltip": "No definido en la configuración: sfdx-hardis aplica este valor predeterminado",
   "deleteDataFromOrgWithSfdmu": "Eliminar datos de la org con SFDMU",
   "deleteDataTooltip": "Eliminar datos de la org usando archivos de configuración SFDMU",
   "deleteLabel": "Eliminar",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -364,6 +364,8 @@
   "debuggerDescription": "Déboguez le code Apex Salesforce avec l'analyse de journaux intégrée et la gestion des checkpoints.",
   "debuggingOptions": "Options de débogage pour l'extension.",
   "defaultOrgLabel": "Org par défaut",
+  "defaultValueBadge": "Par défaut",
+  "defaultValueTooltip": "Non défini dans la configuration : sfdx-hardis applique cette valeur par défaut",
   "deleteDataFromOrgWithSfdmu": "Supprimer des données de l'org avec SFDMU",
   "deleteDataTooltip": "Supprimer des données de l'org en utilisant les fichiers de configuration SFDMU",
   "deleteLabel": "Supprimer",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -364,6 +364,8 @@
   "debuggerDescription": "Esegui il debug del codice Salesforce Apex con analisi dei log integrata e gestione dei checkpoint.",
   "debuggingOptions": "Opzioni di debug per l'estensione.",
   "defaultOrgLabel": "Org predefinita",
+  "defaultValueBadge": "Predefinito",
+  "defaultValueTooltip": "Non definito nella configurazione: sfdx-hardis applica questo valore predefinito",
   "deleteDataFromOrgWithSfdmu": "Elimina dati dall'org con SFDMU",
   "deleteDataTooltip": "Elimina dati dall'org usando i file di configurazione SFDMU",
   "deleteLabel": "Elimina",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -364,6 +364,8 @@
   "debuggerDescription": "統合ログ分析とチェックポイント管理を使用して Salesforce Apex コードをデバッグします。",
   "debuggingOptions": "拡張機能のデバッグオプション。",
   "defaultOrgLabel": "デフォルト組織",
+  "defaultValueBadge": "既定",
+  "defaultValueTooltip": "設定ファイルに未設定です。sfdx-hardis はこの既定値を適用します",
   "deleteDataFromOrgWithSfdmu": "SFDMU で組織からデータを削除",
   "deleteDataTooltip": "SFDMU 設定ファイルを使用して組織からデータを削除します",
   "deleteLabel": "削除",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -364,6 +364,8 @@
   "debuggerDescription": "Debug Salesforce Apex-code met geïntegreerde loganalyse en checkpointbeheer.",
   "debuggingOptions": "Debugging-opties voor de extensie.",
   "defaultOrgLabel": "Standaard org",
+  "defaultValueBadge": "Standaard",
+  "defaultValueTooltip": "Niet ingesteld in de configuratie: sfdx-hardis past deze standaardwaarde toe",
   "deleteDataFromOrgWithSfdmu": "Data uit org verwijderen met SFDMU",
   "deleteDataTooltip": "Data uit org verwijderen met behulp van SFDMU-configuratiebestanden",
   "deleteLabel": "Verwijderen",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -364,6 +364,8 @@
   "debuggerDescription": "Debuguj kod Apex Salesforce ze zintegrowaną analizą logów i zarządzaniem punktami kontrolnymi.",
   "debuggingOptions": "Opcje debugowania rozszerzenia.",
   "defaultOrgLabel": "Domyślny org",
+  "defaultValueBadge": "Domyślnie",
+  "defaultValueTooltip": "Nieokreślone w konfiguracji: sfdx-hardis stosuje tę wartość domyślną",
   "deleteDataFromOrgWithSfdmu": "Usuń dane z org za pomocą SFDMU",
   "deleteDataTooltip": "Usuń dane z org przy użyciu plików konfiguracyjnych SFDMU",
   "deleteLabel": "Usuń",

--- a/src/i18n/pt-BR.json
+++ b/src/i18n/pt-BR.json
@@ -364,6 +364,8 @@
   "debuggerDescription": "Depure código Apex do Salesforce com análise integrada de logs e gerenciamento de checkpoints.",
   "debuggingOptions": "Opções de depuração para a extensão.",
   "defaultOrgLabel": "Org Padrão",
+  "defaultValueBadge": "Padrão",
+  "defaultValueTooltip": "Não definido na configuração: o sfdx-hardis aplica este valor padrão",
   "deleteDataFromOrgWithSfdmu": "Excluir dados da org com SFDMU",
   "deleteDataTooltip": "Excluir dados da org usando arquivos de configuração SFDMU",
   "deleteLabel": "Excluir",

--- a/src/test/suite/anonymizationConfig.test.ts
+++ b/src/test/suite/anonymizationConfig.test.ts
@@ -3,7 +3,12 @@ import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
 import yaml from "js-yaml";
-import { LOCALES, loadLocale, readModuleFile } from "./lwcSourceUtils";
+import {
+  LOCALES,
+  assertKeysTranslated,
+  loadLocale,
+  readModuleFile,
+} from "./lwcSourceUtils";
 import { SfdxHardisConfigHelper } from "../../utils/pipeline/sfdxHardisConfigHelper";
 
 /**
@@ -219,15 +224,7 @@ suite("Anonymization configuration contract", () => {
       usedKeys.add(match[1]);
     }
     assert.ok(usedKeys.size > 10, "the editor must be fully translated");
-    for (const locale of LOCALES) {
-      const translations = loadLocale(locale);
-      for (const key of usedKeys) {
-        assert.ok(
-          typeof translations[key] === "string" && translations[key].length > 0,
-          `missing i18n key "${key}" in ${locale}.json`,
-        );
-      }
-    }
+    assertKeysTranslated(usedKeys);
   });
 
   test("the Security & Privacy section label is translated in the 9 locales", () => {

--- a/src/test/suite/configValueDisplay.test.ts
+++ b/src/test/suite/configValueDisplay.test.ts
@@ -2,9 +2,8 @@ import * as assert from "assert";
 import * as fs from "fs";
 import * as path from "path";
 import {
-  LOCALES,
   REPO_ROOT,
-  loadLocale,
+  assertKeysTranslated,
   readModuleFile,
 } from "./lwcSourceUtils";
 
@@ -104,11 +103,11 @@ suite("Configuration value display contract", () => {
     // Every value carries the full text in its tooltip, so a wrapped or
     // truncated one stays reachable
     const rendered = (viewBlock.match(/\{entry\.valueText\}/g) || []).length;
-    const tooltipped = (viewBlock.match(/title=\{entry\.valueTitle\}/g) || [])
+    const withTooltip = (viewBlock.match(/title=\{entry\.valueTitle\}/g) || [])
       .length;
     assert.ok(rendered >= 4, "every scalar type must render entry.valueText");
     assert.strictEqual(
-      tooltipped,
+      withTooltip,
       rendered,
       "every rendered value must carry its full text in a tooltip",
     );
@@ -382,15 +381,7 @@ suite("Configuration value display contract", () => {
   });
 
   test('the "Default" marker is translated in the 9 locales', () => {
-    for (const locale of LOCALES) {
-      const translations = loadLocale(locale);
-      for (const key of ["defaultValueBadge", "defaultValueTooltip"]) {
-        assert.ok(
-          typeof translations[key] === "string" && translations[key].length > 0,
-          `missing i18n key "${key}" in ${locale}.json`,
-        );
-      }
-    }
+    assertKeysTranslated(["defaultValueBadge", "defaultValueTooltip"]);
   });
 
   test("every i18n key of the settings panel exists in the 9 locales", () => {
@@ -402,14 +393,6 @@ suite("Configuration value display contract", () => {
       usedKeys.add(match[1]);
     }
     assert.ok(usedKeys.size > 10, "the panel must be fully translated");
-    for (const locale of LOCALES) {
-      const translations = loadLocale(locale);
-      for (const key of usedKeys) {
-        assert.ok(
-          typeof translations[key] === "string" && translations[key].length > 0,
-          `missing i18n key "${key}" in ${locale}.json`,
-        );
-      }
-    }
+    assertKeysTranslated(usedKeys);
   });
 });

--- a/src/test/suite/configValueDisplay.test.ts
+++ b/src/test/suite/configValueDisplay.test.ts
@@ -1,0 +1,415 @@
+import * as assert from "assert";
+import * as fs from "fs";
+import * as path from "path";
+import {
+  LOCALES,
+  REPO_ROOT,
+  loadLocale,
+  readModuleFile,
+} from "./lwcSourceUtils";
+
+/**
+ * Contract tests for the READ-ONLY value of a configuration setting
+ * (Global Pipeline Settings, branch settings, Extension Settings).
+ *
+ * The bug they lock down: a setting that WAS configured used to be printed
+ * with the SLDS "weak" text color, the very color of the row help text and of
+ * the "Not defined" placeholder. Only booleans (status pill) and arrays
+ * (chips) were readable, so the panel looked like it had no values at all.
+ *
+ * The LWC bundle cannot run in the extension test host, so the rendering
+ * contract is asserted on the component sources, while the pure helpers of
+ * s/configValueUtils are evaluated for real.
+ */
+
+/** Loads the pure helpers of s/configValueUtils as a plain object. */
+function loadConfigValueUtils(): any {
+  const source = readModuleFile("configValueUtils", "configValueUtils.js")
+    // The module is authored as an ES module for the LWC compiler; the test
+    // host only needs its (side-effect free) function bodies.
+    .replace(/^export /gm, "");
+  const factory = new Function(
+    `${source}
+    return { BRANCH_NAME_KEYS, isBranchNameKey, configChipClass, isUrlConfigValue,
+             isEmptyConfigValue, isTechnicalConfigValue, formatConfigValue,
+             configValueClass, formatConfigDefault };`,
+  );
+  return factory();
+}
+
+suite("Configuration value display contract", () => {
+  const html = readModuleFile("pipelineConfig", "pipelineConfig.html");
+  const js = readModuleFile("pipelineConfig", "pipelineConfig.js");
+  const css = readModuleFile("pipelineConfig", "pipelineConfig.css");
+  const globalTheme = fs.readFileSync(
+    path.join(REPO_ROOT, "resources", "global-theme.css"),
+    "utf8",
+  );
+
+  // The read-only branch of a field row: from the view-mode template holding
+  // the boolean pill, down to the "inherited" chip that closes it.
+  const viewBlockStart = html.lastIndexOf(
+    "<template if:false={isEditMode}>",
+    html.indexOf("{entry.booleanPillLabel}"),
+  );
+  const viewBlock = html.substring(
+    viewBlockStart,
+    html.indexOf("</div>", html.indexOf("{i18n.inherited}", viewBlockStart)),
+  );
+
+  test("the read-only block of a field row was located", () => {
+    assert.ok(viewBlockStart > 0, "view-mode block not found in the template");
+    assert.ok(
+      viewBlock.length > 500 && viewBlock.includes("{i18n.notDefined}"),
+      "the extracted view-mode block does not look like the value renderer",
+    );
+  });
+
+  test("a configured value is never printed with the muted help-text color", () => {
+    assert.ok(
+      !viewBlock.includes("slds-text-color_weak"),
+      "a value must not reuse the color of the row help text and of the " +
+        '"Not defined" placeholder: it made a configured setting look empty',
+    );
+    // Text and number values use the strong, theme-aware kit class
+    assert.ok(
+      viewBlock.includes("class={entry.valueClass}"),
+      "scalar values must be rendered with the computed .hardis-field-value class",
+    );
+    assert.ok(
+      globalTheme.includes(".hardis-field-value {"),
+      "global-theme.css must declare the shared .hardis-field-value class",
+    );
+  });
+
+  test("every value type answers with something readable", () => {
+    // Booleans keep their status pill, arrays their chips, and enums now get
+    // a chip too instead of a line of grey text
+    assert.ok(viewBlock.includes("{entry.booleanPillLabel}"), "boolean pill");
+    assert.ok(
+      viewBlock.includes("class={entry.chipClass} title={item}"),
+      "array values must stay rendered as chips",
+    );
+    assert.ok(
+      viewBlock.includes(
+        "<span class={entry.chipClass} title={entry.valueTitle}>{entry.valueText}</span>",
+      ),
+      "an enum value must be rendered as a chip carrying its raw value in the tooltip",
+    );
+    // A git branch name reuses the monospace branch chip of the branch arrays
+    assert.ok(
+      viewBlock.includes('<span class="hardis-branch-chip"'),
+      "a scalar branch name must reuse the branch chip of the branch arrays",
+    );
+    // Every value carries the full text in its tooltip, so a wrapped or
+    // truncated one stays reachable
+    const rendered = (viewBlock.match(/\{entry\.valueText\}/g) || []).length;
+    const tooltipped = (viewBlock.match(/title=\{entry\.valueTitle\}/g) || [])
+      .length;
+    assert.ok(rendered >= 4, "every scalar type must render entry.valueText");
+    assert.strictEqual(
+      tooltipped,
+      rendered,
+      "every rendered value must carry its full text in a tooltip",
+    );
+  });
+
+  test('one single "Not defined" placeholder drives every field type', () => {
+    const occurrences = viewBlock.match(/\{i18n\.notDefined\}/g) || [];
+    assert.strictEqual(
+      occurrences.length,
+      1,
+      "the empty state must be rendered once, from entry.hasReadOnlyValue",
+    );
+    assert.ok(
+      viewBlock.includes("<template if:false={entry.hasReadOnlyValue}>"),
+      "the empty state must be driven by the computed hasReadOnlyValue flag",
+    );
+    assert.match(
+      js,
+      /let hasReadOnlyValue = false;/,
+      "hasReadOnlyValue must be computed by the component",
+    );
+  });
+
+  test("a value nobody configured is marked as the default", () => {
+    // The panel receives the schema default in place of a missing value
+    // (getEditorInput substitutes it), so without this marker a default is
+    // indistinguishable from a deliberate choice
+    assert.ok(
+      viewBlock.includes("{i18n.defaultValueBadge}"),
+      "a defaulted value must be marked as such",
+    );
+    assert.ok(
+      viewBlock.includes("<template if:true={entry.isDefaultValue}>"),
+      "the marker must be driven by the computed isDefaultValue flag",
+    );
+    assert.match(
+      js,
+      /const isDefaultValue =\s*!isBoolean &&\s*hasReadOnlyValue &&\s*configuredValue === undefined &&\s*formatConfigDefault\(schema, enumNames\) !== "";/,
+      "a value is a default only when no configuration file carries it",
+    );
+    assert.match(
+      js,
+      /branchConfig && branchConfig\[key\] !== undefined/,
+      "the branch file must be checked before the global one",
+    );
+    // The schema really carries the defaults the panel substitutes
+    const schema = JSON.parse(
+      fs.readFileSync(
+        path.join(REPO_ROOT, "resources", "sfdx-hardis.jsonschema.json"),
+        "utf8",
+      ),
+    );
+    assert.strictEqual(
+      schema.properties.apexTestsMinCoverageOrgWide.default,
+      75,
+      "the JSON schema must expose the defaults the panel recalls",
+    );
+    const helper = fs.readFileSync(
+      path.join(
+        REPO_ROOT,
+        "src",
+        "utils",
+        "pipeline",
+        "sfdxHardisConfigHelper.ts",
+      ),
+      "utf8",
+    );
+    assert.match(
+      helper,
+      /default: value\.default,/,
+      "the config helper must forward the schema default to the webview",
+    );
+    assert.match(
+      helper,
+      /config\[key\] = schemaEntry\.default;/,
+      "the panel is fed with the schema default when nothing is configured",
+    );
+  });
+
+  test("every entry property used by the read-only block is computed", () => {
+    const used = new Set<string>();
+    for (const match of viewBlock.matchAll(/\{entry\.(\w+)\}/g)) {
+      used.add(match[1]);
+    }
+    assert.ok(
+      used.size > 8,
+      "the read-only block should use several properties",
+    );
+    for (const property of used) {
+      assert.ok(
+        new RegExp(`(^|[\\s{,])${property}[,:\\s]`, "m").test(js),
+        `the component never computes entry.${property}`,
+      );
+    }
+  });
+
+  test("branch settings never show an inherited value as [object Object]", () => {
+    assert.ok(
+      html.includes("{i18n.globalValueLabel} {entry.globalValueDisplay}"),
+      "the inherited global value must be printed through the shared formatter",
+    );
+    assert.match(
+      js,
+      /const globalValueDisplay = formatConfigValue\(globalValue\);/,
+    );
+  });
+
+  test("Extension Settings recall the default of an empty free-text setting", () => {
+    const extensionHtml = readModuleFile(
+      "extensionConfig",
+      "extensionConfig.html",
+    );
+    const extensionJs = readModuleFile("extensionConfig", "extensionConfig.js");
+    assert.match(
+      extensionJs,
+      /const defaultPlaceholder = formatConfigValue\(entry\.default\);/,
+      "the placeholder must come from the shared formatter",
+    );
+    assert.strictEqual(
+      (extensionHtml.match(/placeholder=\{entry\.defaultPlaceholder\}/g) || [])
+        .length,
+      2,
+      "the text and the number inputs must both show their default",
+    );
+  });
+
+  suite("s/configValueUtils helpers", () => {
+    const utils = loadConfigValueUtils();
+
+    test("an empty value is recognized whatever its shape", () => {
+      for (const empty of [undefined, null, "", "   ", [], {}]) {
+        assert.strictEqual(
+          utils.isEmptyConfigValue(empty),
+          true,
+          String(empty),
+        );
+      }
+      for (const filled of [0, false, "x", ["a"], { a: 1 }]) {
+        assert.strictEqual(
+          utils.isEmptyConfigValue(filled),
+          false,
+          JSON.stringify(filled),
+        );
+      }
+    });
+
+    test("technical strings are the only ones rendered in monospace", () => {
+      for (const technical of [
+        "^[A-Z]{2,}-\\d+$",
+        // A regular expression stays technical even when it holds a space
+        "^CRM-[0-9]+ .*",
+        "CRM-[0-9]+",
+        "force-app/main/default",
+        "MyClass.cls",
+      ]) {
+        assert.strictEqual(
+          utils.isTechnicalConfigValue(technical),
+          true,
+          technical,
+        );
+        assert.strictEqual(
+          utils.configValueClass(technical),
+          "hardis-field-value mono",
+        );
+      }
+      for (const prose of [
+        "integration",
+        "Sandbox Orgs",
+        // A sentence holding a parenthesis is prose, not a pattern
+        "New features and enhancements (BUILD)",
+        "CRM-1042 Account hierarchy",
+        42,
+        undefined,
+      ]) {
+        assert.strictEqual(
+          utils.isTechnicalConfigValue(prose),
+          false,
+          String(prose),
+        );
+        assert.strictEqual(utils.configValueClass(prose), "hardis-field-value");
+      }
+    });
+
+    test("values are printed, never left as [object Object]", () => {
+      assert.strictEqual(utils.formatConfigValue(["a", "b"]), "a, b");
+      assert.strictEqual(utils.formatConfigValue({ a: 1 }), '{"a":1}');
+      assert.strictEqual(utils.formatConfigValue(0), "0");
+      assert.strictEqual(utils.formatConfigValue(false), "false");
+      assert.strictEqual(utils.formatConfigValue(undefined), "");
+    });
+
+    test("git branch values reuse the monospace branch chip", () => {
+      for (const key of [
+        "mergeTargets",
+        "availableTargetBranches",
+        "developmentBranch",
+      ]) {
+        assert.strictEqual(utils.configChipClass(key), "hardis-branch-chip");
+      }
+      assert.strictEqual(
+        utils.configChipClass("allowedOrgTypes"),
+        "hardis-chip",
+      );
+    });
+
+    test("only a default that tells something is recalled", () => {
+      assert.strictEqual(utils.formatConfigDefault({ default: 75 }), "75");
+      assert.strictEqual(utils.formatConfigDefault({ default: "" }), "");
+      assert.strictEqual(utils.formatConfigDefault({ default: [] }), "");
+      assert.strictEqual(utils.formatConfigDefault({ default: { a: 1 } }), "");
+      assert.strictEqual(utils.formatConfigDefault(null), "");
+      // An enum default is recalled with its human label, not its raw value
+      assert.strictEqual(
+        utils.formatConfigDefault(
+          { default: "externalFile", enum: ["externalFile", "sfdxHardis"] },
+          ["External file", "sfdx-hardis"],
+        ),
+        "External file",
+      );
+    });
+
+    test("http(s) values are the ones turned into a link", () => {
+      assert.strictEqual(utils.isUrlConfigValue("https://example.com"), true);
+      assert.strictEqual(utils.isUrlConfigValue(" http://a.b "), true);
+      assert.strictEqual(utils.isUrlConfigValue("integration"), false);
+      assert.strictEqual(utils.isUrlConfigValue(42), false);
+    });
+  });
+
+  test("the value classes are declared once, in the shared kit", () => {
+    for (const className of [
+      "hardis-field-value",
+      "hardis-not-set",
+      "hardis-field-default",
+      "hardis-url-link",
+    ]) {
+      assert.ok(
+        globalTheme.includes(`.${className}`),
+        `global-theme.css must own .${className}`,
+      );
+      assert.ok(
+        !css.includes(`.${className} {`),
+        `pipelineConfig.css must not redefine .${className}`,
+      );
+    }
+  });
+
+  test("the value styles are theme-aware", () => {
+    for (const stylesheet of [
+      css,
+      readModuleFile("extensionConfig", "extensionConfig.css"),
+    ]) {
+      assert.doesNotMatch(
+        stylesheet,
+        /#[0-9a-fA-F]{3,8}\b|rgba?\(|color:\s*(white|black)/,
+        "colors must come from the hardis kit, so both VS Code themes render",
+      );
+    }
+    // The shared rules paint with palette tokens and never per theme
+    const valueRule = globalTheme.substring(
+      globalTheme.indexOf(".hardis-field-value {"),
+      globalTheme.indexOf(".hardis-url-link {"),
+    );
+    assert.ok(valueRule.length > 100, "the value rules were not found");
+    assert.doesNotMatch(
+      valueRule,
+      /#[0-9a-fA-F]{3,8}\b|rgba?\(|\[data-theme=/,
+      "the value rules must use palette tokens, not colors nor per-theme copies",
+    );
+    assert.match(valueRule, /var\(--slds-g-color-neutral-base-10\)/);
+  });
+
+  test('the "Default" marker is translated in the 9 locales', () => {
+    for (const locale of LOCALES) {
+      const translations = loadLocale(locale);
+      for (const key of ["defaultValueBadge", "defaultValueTooltip"]) {
+        assert.ok(
+          typeof translations[key] === "string" && translations[key].length > 0,
+          `missing i18n key "${key}" in ${locale}.json`,
+        );
+      }
+    }
+  });
+
+  test("every i18n key of the settings panel exists in the 9 locales", () => {
+    const usedKeys = new Set<string>();
+    for (const match of html.matchAll(/\{i18n\.(\w+)\}/g)) {
+      usedKeys.add(match[1]);
+    }
+    for (const match of js.matchAll(/this\.i18n\.(\w+)/g)) {
+      usedKeys.add(match[1]);
+    }
+    assert.ok(usedKeys.size > 10, "the panel must be fully translated");
+    for (const locale of LOCALES) {
+      const translations = loadLocale(locale);
+      for (const key of usedKeys) {
+        assert.ok(
+          typeof translations[key] === "string" && translations[key].length > 0,
+          `missing i18n key "${key}" in ${locale}.json`,
+        );
+      }
+    }
+  });
+});

--- a/src/test/suite/lwcSourceUtils.ts
+++ b/src/test/suite/lwcSourceUtils.ts
@@ -1,3 +1,4 @@
+import * as assert from "assert";
 import * as fs from "fs";
 import * as path from "path";
 
@@ -52,4 +53,21 @@ export function loadLocale(locale: string): Record<string, string> {
       "utf8",
     ),
   );
+}
+
+/**
+ * Asserts that every given key is translated in the 9 locales.
+ * The LWC contract suites all end with this same check.
+ */
+export function assertKeysTranslated(keys: Iterable<string>): void {
+  const keyList = [...keys];
+  for (const locale of LOCALES) {
+    const translations = loadLocale(locale);
+    for (const key of keyList) {
+      assert.ok(
+        typeof translations[key] === "string" && translations[key].length > 0,
+        `missing i18n key "${key}" in ${locale}.json`,
+      );
+    }
+  }
 }

--- a/src/webviews/lwc-ui/modules/s/configValueUtils/configValueUtils.js
+++ b/src/webviews/lwc-ui/modules/s/configValueUtils/configValueUtils.js
@@ -24,14 +24,12 @@
  *   as a deliberate choice
  */
 
-/** Text values starting with http(s): rendered as a clickable link. */
-export const URL_VALUE_REGEX = /^https?:\/\//i;
+// Text values starting with http(s): rendered as a clickable link.
+const URL_VALUE_REGEX = /^https?:\/\//i;
 
-/**
- * Configuration keys holding git branch names (scalar or array): their values
- * are rendered as monospace branch chips instead of plain text.
- */
-export const BRANCH_NAME_KEYS = new Set([
+// Configuration keys holding git branch names (scalar or array): their values
+// are rendered as monospace branch chips instead of plain text.
+const BRANCH_NAME_KEYS = new Set([
   "mergeTargets",
   "availableTargetBranches",
   "developmentBranch",
@@ -118,9 +116,10 @@ export function configValueClass(value) {
 }
 
 /**
- * Printable default of a setting, recalled next to an empty value.
- * Returns "" when the schema has no usable default (unset, empty string,
- * empty array or nested object: none of them tells the user anything).
+ * Printable default of a setting, with the human label of an enum default.
+ * Returns "" when the schema has no default worth telling the user about
+ * (unset, empty string, empty array or nested object), which is also how a
+ * panel decides whether a displayed value can be a substituted default.
  * @param {object} schema the JSON schema of the setting
  * @param {Array} enumNames human labels of schema.enum, when any
  */

--- a/src/webviews/lwc-ui/modules/s/configValueUtils/configValueUtils.js
+++ b/src/webviews/lwc-ui/modules/s/configValueUtils/configValueUtils.js
@@ -1,0 +1,142 @@
+/* eslint-disable */
+// LWC: ignore parsing errors for import/export, handled by LWC compiler
+// @ts-nocheck
+// eslint-env es6
+
+/**
+ * Shared helpers rendering the value of a configuration setting in the
+ * read-only state of a configuration panel (Pipeline Settings, branch
+ * settings, and any future panel built on the .hardis-field-row kit).
+ *
+ * Before these helpers, a value that WAS set (a branch name, a regex, a
+ * number, an enum) was printed with the SLDS "weak" text color, the very
+ * color used by the row help text and by the "Not defined" placeholder: a
+ * configured setting looked exactly like an empty one. Booleans (status
+ * pill) and arrays (chips) were the only readable values of the panel.
+ *
+ * The rules applied here, so every panel renders a value the same way:
+ * - a value that is set uses the strong .hardis-field-value class
+ * - technical strings (regex, path, api name) also get the monospace variant
+ * - git branch names reuse the .hardis-branch-chip of the array chips
+ * - an empty value keeps the italic .hardis-not-set placeholder
+ * - a value nobody configured (the panel receives the schema default in place
+ *   of the missing value) is marked as such, so a default is never passed off
+ *   as a deliberate choice
+ */
+
+/** Text values starting with http(s): rendered as a clickable link. */
+export const URL_VALUE_REGEX = /^https?:\/\//i;
+
+/**
+ * Configuration keys holding git branch names (scalar or array): their values
+ * are rendered as monospace branch chips instead of plain text.
+ */
+export const BRANCH_NAME_KEYS = new Set([
+  "mergeTargets",
+  "availableTargetBranches",
+  "developmentBranch",
+]);
+
+// A technical string carries characters that matter and must stay legible
+// (regex metacharacters, path separators, dotted api names).
+// A regular expression is recognized by its anchors, even when it holds
+// spaces ("^CRM-[0-9]+ .*").
+const REGEX_ANCHOR_REGEX = /^\^|\$$/;
+// Any other value must be a single token: a sentence holding a parenthesis
+// ("New features (BUILD)") is prose and stays in the panel font.
+const TECHNICAL_TOKEN_REGEX = /[\\/^$*+?()[\]{}|]|^\S+\.\S+$/;
+
+/** True when the key holds one or several git branch names. */
+export function isBranchNameKey(key) {
+  return BRANCH_NAME_KEYS.has(key);
+}
+
+/** CSS class of the chip(s) rendering the value(s) of a setting. */
+export function configChipClass(key) {
+  return isBranchNameKey(key) ? "hardis-branch-chip" : "hardis-chip";
+}
+
+/** True when the value is a http(s) URL, rendered as a clickable link. */
+export function isUrlConfigValue(value) {
+  return typeof value === "string" && URL_VALUE_REGEX.test(value.trim());
+}
+
+/** True when a setting holds no value at all (unset, null or blank string). */
+export function isEmptyConfigValue(value) {
+  if (value === undefined || value === null) {
+    return true;
+  }
+  if (Array.isArray(value)) {
+    return value.length === 0;
+  }
+  if (typeof value === "object") {
+    return Object.keys(value).length === 0;
+  }
+  return String(value).trim() === "";
+}
+
+/** True when the string is technical enough to deserve a monospace render. */
+export function isTechnicalConfigValue(value) {
+  if (typeof value !== "string") {
+    return false;
+  }
+  const trimmed = value.trim();
+  if (trimmed === "") {
+    return false;
+  }
+  if (REGEX_ANCHOR_REGEX.test(trimmed)) {
+    return true;
+  }
+  return !/\s/.test(trimmed) && TECHNICAL_TOKEN_REGEX.test(trimmed);
+}
+
+/**
+ * Printable form of a scalar or array value, for a read-only row or a tooltip.
+ * Objects are JSON so a nested block never shows up as "[object Object]".
+ */
+export function formatConfigValue(value) {
+  if (isEmptyConfigValue(value)) {
+    return "";
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => formatConfigValue(item)).join(", ");
+  }
+  if (typeof value === "object") {
+    return JSON.stringify(value);
+  }
+  return String(value);
+}
+
+/**
+ * CSS classes of a value that is set: strong text, monospace when technical.
+ * @param {*} value the value about to be displayed
+ */
+export function configValueClass(value) {
+  return isTechnicalConfigValue(value)
+    ? "hardis-field-value mono"
+    : "hardis-field-value";
+}
+
+/**
+ * Printable default of a setting, recalled next to an empty value.
+ * Returns "" when the schema has no usable default (unset, empty string,
+ * empty array or nested object: none of them tells the user anything).
+ * @param {object} schema the JSON schema of the setting
+ * @param {Array} enumNames human labels of schema.enum, when any
+ */
+export function formatConfigDefault(schema, enumNames) {
+  if (!schema || isEmptyConfigValue(schema.default)) {
+    return "";
+  }
+  const defaultValue = schema.default;
+  if (typeof defaultValue === "object") {
+    return "";
+  }
+  if (Array.isArray(schema.enum) && Array.isArray(enumNames)) {
+    const idx = schema.enum.indexOf(defaultValue);
+    if (idx !== -1 && enumNames[idx]) {
+      return String(enumNames[idx]);
+    }
+  }
+  return formatConfigValue(defaultValue);
+}

--- a/src/webviews/lwc-ui/modules/s/extensionConfig/extensionConfig.html
+++ b/src/webviews/lwc-ui/modules/s/extensionConfig/extensionConfig.html
@@ -94,6 +94,7 @@
                                                               onchange={handleTextChange}
                                                               label={entry.label}
                                                               variant="label-hidden"
+                                                              placeholder={entry.defaultPlaceholder}
                                                           ></lightning-input>
                                                       </template>
                                                       <template if:true={entry.isNumber}>
@@ -104,6 +105,7 @@
                                                               onchange={handleNumberChange}
                                                               label={entry.label}
                                                               variant="label-hidden"
+                                                              placeholder={entry.defaultPlaceholder}
                                                           ></lightning-input>
                                                       </template>
                                                       <template if:true={entry.isArray}>

--- a/src/webviews/lwc-ui/modules/s/extensionConfig/extensionConfig.js
+++ b/src/webviews/lwc-ui/modules/s/extensionConfig/extensionConfig.js
@@ -1,5 +1,6 @@
 import { LightningElement, track, api } from "lwc";
 import { SharedMixin } from "s/sharedMixin";
+import { formatConfigValue } from "s/configValueUtils";
 
 export default class ExtensionConfig extends SharedMixin(LightningElement) {
   @track sections = [];
@@ -65,8 +66,12 @@ export default class ExtensionConfig extends SharedMixin(LightningElement) {
         const description = entry.description || "";
         const isMultilineHelp = description.includes("\n");
         const helpFirstLine = description.split(/\r?\n/)[0] || "";
+        // A setting left empty still tells what applies: its default is shown
+        // as the placeholder of the free-text controls.
+        const defaultPlaceholder = formatConfigValue(entry.default);
         return {
           ...entry,
+          defaultPlaceholder,
           valueString,
           valueBoolean,
           valueEnum,

--- a/src/webviews/lwc-ui/modules/s/pipelineConfig/pipelineConfig.css
+++ b/src/webviews/lwc-ui/modules/s/pipelineConfig/pipelineConfig.css
@@ -24,16 +24,6 @@ lightning-datatable {
 	margin-top: 0.5rem;
 }
 
-/* Unset/empty value placeholder ("Not set") */
-.hardis-not-set {
-	font-style: italic;
-}
-
-/* Truncated clickable URL value, full URL available in the title attribute */
-.hardis-url-link {
-	display: inline-block;
-	max-width: 260px;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	vertical-align: bottom;
-}
+/* The read-only value classes (.hardis-field-value, .hardis-not-set,
+   .hardis-field-default, .hardis-url-link) live in global-theme.css so every
+   configuration panel renders a value the same way. */

--- a/src/webviews/lwc-ui/modules/s/pipelineConfig/pipelineConfig.html
+++ b/src/webviews/lwc-ui/modules/s/pipelineConfig/pipelineConfig.html
@@ -347,7 +347,7 @@
                             ></lightning-input>
                           </template>
                           <template if:true={entry.inherited}>
-                            <div class="hardis-field-help">{i18n.globalValueLabel} {entry.globalValue}</div>
+                            <div class="hardis-field-help">{i18n.globalValueLabel} {entry.globalValueDisplay}</div>
                           </template>
                         </template>
                         <template if:false={isEditMode}>
@@ -357,35 +357,25 @@
                             </span>
                           </template>
                           <template if:false={entry.isBoolean}>
-                            <template if:true={entry.isAnonymization}>
-                              <s-anonymization-config
-                                value={entry.value}
-                                doc-url={entry.docUrl}
-                                read-only={isViewMode}
-                              ></s-anonymization-config>
-                            </template>
-                            <template if:true={entry.isArrayEnum}>
-                              <template if:true={entry.hasArrayEnumValues}>
+                            <template if:true={entry.hasReadOnlyValue}>
+                              <template if:true={entry.isAnonymization}>
+                                <s-anonymization-config
+                                  value={entry.value}
+                                  doc-url={entry.docUrl}
+                                  read-only={isViewMode}
+                                ></s-anonymization-config>
+                              </template>
+                              <template if:true={entry.isArrayEnum}>
                                 <template for:each={entry.valueDisplay} for:item="item">
-                                  <span key={item} class={entry.arrayChipClass}>{item}</span>
+                                  <span key={item} class={entry.chipClass} title={item}>{item}</span>
                                 </template>
                               </template>
-                              <template if:false={entry.hasArrayEnumValues}>
-                                <span class="slds-text-color_weak hardis-not-set">{i18n.notDefined}</span>
-                              </template>
-                            </template>
-                            <template if:true={entry.isArrayText}>
-                              <template if:true={entry.hasArrayTextValues}>
+                              <template if:true={entry.isArrayText}>
                                 <template for:each={entry.valueDisplay} for:item="item">
-                                  <span key={item} class={entry.arrayChipClass}>{item}</span>
+                                  <span key={item} class={entry.chipClass} title={item}>{item}</span>
                                 </template>
                               </template>
-                              <template if:false={entry.hasArrayTextValues}>
-                                <span class="slds-text-color_weak hardis-not-set">{i18n.notDefined}</span>
-                              </template>
-                            </template>
-                            <template if:true={entry.isArrayObject}>
-                              <template if:true={entry.hasArrayObjectValues}>
+                              <template if:true={entry.isArrayObject}>
                                 <s-hardis-datatable
                                   key-field="_index"
                                   data={entry.arrayObjectDatatableData}
@@ -397,38 +387,31 @@
                                   class="slds-m-top_x-small"
                                 ></s-hardis-datatable>
                               </template>
-                              <template if:false={entry.hasArrayObjectValues}>
-                                <span class="slds-text-color_weak hardis-not-set">{i18n.notDefined}</span>
+                              <template if:true={entry.isEnum}>
+                                <span class={entry.chipClass} title={entry.valueTitle}>{entry.valueText}</span>
                               </template>
-                            </template>
-                            <template if:true={entry.isEnum}>
-                              <template if:true={entry.value}>
-                                <span class="slds-text-color_weak">{entry.valueDisplay}</span>
-                              </template>
-                              <template if:false={entry.value}>
-                                <span class="slds-text-color_weak hardis-not-set">{i18n.notDefined}</span>
-                              </template>
-                            </template>
-                            <template if:true={entry.isText}>
-                              <template if:true={entry.hasValue}>
+                              <template if:true={entry.isText}>
                                 <template if:true={entry.isUrlValue}>
-                                  <button type="button" class="hardis-textlink hardis-url-link" title={entry.value} onclick={handleOpenDocUrl} data-doc-url={entry.value}>{entry.value}</button>
+                                  <button type="button" class="hardis-textlink hardis-url-link" title={entry.valueTitle} onclick={handleOpenDocUrl} data-doc-url={entry.value}>{entry.valueText}</button>
                                 </template>
                                 <template if:false={entry.isUrlValue}>
-                                  <span class="slds-text-color_weak">{entry.value}</span>
+                                  <template if:true={entry.isBranchTextValue}>
+                                    <span class="hardis-branch-chip" title={entry.valueTitle}>{entry.valueText}</span>
+                                  </template>
+                                  <template if:false={entry.isBranchTextValue}>
+                                    <span class={entry.valueClass} title={entry.valueTitle}>{entry.valueText}</span>
+                                  </template>
                                 </template>
                               </template>
-                              <template if:false={entry.hasValue}>
-                                <span class="slds-text-color_weak hardis-not-set">{i18n.notDefined}</span>
+                              <template if:true={entry.isNumber}>
+                                <span class={entry.valueClass} title={entry.valueTitle}>{entry.valueText}</span>
                               </template>
                             </template>
-                            <template if:true={entry.isNumber}>
-                              <template if:true={entry.hasValue}>
-                                <span class="slds-text-color_weak">{entry.value}</span>
-                              </template>
-                              <template if:false={entry.hasValue}>
-                                <span class="slds-text-color_weak hardis-not-set">{i18n.notDefined}</span>
-                              </template>
+                            <template if:false={entry.hasReadOnlyValue}>
+                              <span class="hardis-field-value hardis-not-set">{i18n.notDefined}</span>
+                            </template>
+                            <template if:true={entry.isDefaultValue}>
+                              <span class="hardis-field-default" title={i18n.defaultValueTooltip}>{i18n.defaultValueBadge}</span>
                             </template>
                           </template>
                           <template if:true={entry.inherited}>

--- a/src/webviews/lwc-ui/modules/s/pipelineConfig/pipelineConfig.js
+++ b/src/webviews/lwc-ui/modules/s/pipelineConfig/pipelineConfig.js
@@ -7,15 +7,16 @@ import {
   getActionTypePillClass,
   getActionContextPillClass,
 } from "s/deploymentActionUtils";
+import {
+  configChipClass,
+  configValueClass,
+  formatConfigDefault,
+  formatConfigValue,
+  isBranchNameKey,
+  isEmptyConfigValue,
+  isUrlConfigValue,
+} from "s/configValueUtils";
 
-// Config keys that hold git branch names: rendered as monospace branch chips
-// instead of plain chips in the read-only view.
-const BRANCH_NAME_ARRAY_KEYS = new Set([
-  "mergeTargets",
-  "availableTargetBranches",
-]);
-// Text values starting with http(s) are rendered as a truncated clickable link.
-const URL_VALUE_REGEX = /^https?:\/\//i;
 // A section made only of these keys gets the compact "Salesforce Org" card
 // layout in read-only mode instead of a list of field rows.
 const SALESFORCE_ORG_KEYS = ["instanceUrl", "targetUsername"];
@@ -319,15 +320,7 @@ export default class PipelineConfig extends SharedMixin(LightningElement) {
             valueEditText = "[]";
           }
           // Compute hasValue for text and number fields
-          let hasValue = false;
-          if (isText) {
-            hasValue =
-              value !== undefined &&
-              value !== null &&
-              String(value).trim() !== "";
-          } else if (isNumber) {
-            hasValue = value !== undefined && value !== null && value !== "";
-          }
+          const hasValue = (isText || isNumber) && !isEmptyConfigValue(value);
 
           const isApexTestsSelect =
             key === "deploymentApexTestClasses" && isArrayText === true;
@@ -351,14 +344,12 @@ export default class PipelineConfig extends SharedMixin(LightningElement) {
           const booleanPillLabel = value
             ? this.i18n.enabledLabel
             : this.i18n.disabledLabel;
-          const isUrlValue =
-            isText &&
-            typeof value === "string" &&
-            URL_VALUE_REGEX.test(value.trim());
-          const isBranchArrayValue = BRANCH_NAME_ARRAY_KEYS.has(key);
-          const arrayChipClass = isBranchArrayValue
-            ? "hardis-branch-chip"
-            : "hardis-chip";
+          const isUrlValue = isText && isUrlConfigValue(value);
+          // A scalar branch name reuses the monospace branch chip of the
+          // branch arrays, so the same kind of value looks the same everywhere
+          const isBranchTextValue =
+            isText && !isUrlValue && isBranchNameKey(key);
+          const entryChipClass = configChipClass(key);
           // Doc links move inline in the field label; array-of-object fields
           // never carried one (they use their own datatable/modal editor).
           // Nested-object editors carry their own doc link inside the component
@@ -381,6 +372,49 @@ export default class PipelineConfig extends SharedMixin(LightningElement) {
           // Nested objects are edited by a dedicated component, one flag per
           // supported property so the template can pick the right one
           const isAnonymization = isObject && key === "anonymization";
+          // Read-only value: printed with the strong .hardis-field-value class
+          // (monospace when technical) instead of the muted help-text color,
+          // and always carrying the full value in its tooltip so a wrapped or
+          // truncated one stays reachable.
+          const valueText = isEnum
+            ? formatConfigValue(valueDisplay)
+            : formatConfigValue(value);
+          const valueClass = configValueClass(value);
+          // Enums show their human label: the tooltip recalls the raw value
+          // actually written in .sfdx-hardis.yml
+          const rawValueText = formatConfigValue(value);
+          const valueTitle =
+            isEnum && rawValueText && rawValueText !== valueText
+              ? `${valueText} (${rawValueText})`
+              : valueText;
+          // One single "Not defined" placeholder for every field type. The
+          // nested-object editors render themselves, empty or not.
+          let hasReadOnlyValue = false;
+          if (isAnonymization) {
+            hasReadOnlyValue = true;
+          } else if (isArrayEnum || isArrayText || isArrayObject) {
+            hasReadOnlyValue = hasArrayItems;
+          } else {
+            hasReadOnlyValue = !isEmptyConfigValue(value);
+          }
+          // A value nobody wrote: the panel receives the schema default in
+          // place of the missing value, so the row says where it comes from
+          // instead of passing a default off as a deliberate choice.
+          // Booleans are excluded: "Disabled" already reads as "nothing set".
+          const configuredValue =
+            branchConfig && branchConfig[key] !== undefined
+              ? branchConfig[key]
+              : globalConfig
+                ? globalConfig[key]
+                : undefined;
+          const isDefaultValue =
+            !isBoolean &&
+            hasReadOnlyValue &&
+            configuredValue === undefined &&
+            formatConfigDefault(schema, enumNames) !== "";
+          // Branch settings inheriting from the global config: arrays and
+          // objects used to be printed as "[object Object]"
+          const globalValueDisplay = formatConfigValue(globalValue);
           entries.push({
             key,
             isAnonymization,
@@ -415,18 +449,16 @@ export default class PipelineConfig extends SharedMixin(LightningElement) {
             booleanPillClass,
             booleanPillLabel,
             isUrlValue,
-            isBranchArrayValue,
-            arrayChipClass,
+            isBranchTextValue,
+            chipClass: entryChipClass,
+            valueText,
+            valueClass,
+            valueTitle,
+            hasReadOnlyValue,
+            isDefaultValue,
+            globalValueDisplay,
             isWideControl,
             fieldRowClass,
-            hasArrayEnumValues:
-              isArrayEnum &&
-              Array.isArray(valueDisplay) &&
-              valueDisplay.length > 0,
-            hasArrayTextValues:
-              isArrayText &&
-              Array.isArray(valueDisplay) &&
-              valueDisplay.length > 0,
             hasArrayObjectValues:
               isArrayObject &&
               Array.isArray(valueDisplay) &&


### PR DESCRIPTION
## The problem

In the read-only state of **Global Pipeline Settings** (and the branch settings, same component), a setting that *was* configured was printed as:

```html
<span class="slds-text-color_weak">{entry.value}</span>
```

`slds-text-color_weak` is the SLDS muted text color: the exact color already used by the row help text and by the italic **Not defined** placeholder right next to it. So a value that exists and a value that does not look the same, and the eye reads the whole right column as "nothing configured here". Booleans (green/grey status pill) and arrays (chips) were the only values that stood out, which is precisely what the report says.

Two smaller problems came with it:

- a long value had no room: the URL link was capped at 260px with no wrapping, and a plain value span had no `overflow-wrap`, so a regular expression or a path was cut off with no way to read it;
- the panel is fed with the JSON-schema default when a setting is absent from the configuration files (`getEditorInput` substitutes `schemaEntry.default`), so a default was displayed exactly like a deliberate choice.

## Before / after, per field type

| Field type | Before | After |
|---|---|---|
| boolean | green/grey status pill | unchanged |
| text | muted grey, same as the help text | strong `.hardis-field-value`, full value in the tooltip, wraps instead of overflowing |
| text (technical: regex, path, api name) | muted grey | strong **monospace** |
| text (git branch, `developmentBranch`) | muted grey | monospace branch chip, like the branch arrays already were |
| text (http/https) | link truncated at 260px | link truncated to the column, full URL in the tooltip |
| number | muted grey | strong `.hardis-field-value` |
| enum | muted grey label | labelled chip, raw stored value recalled in the tooltip |
| array of text / enum | chips | unchanged, plus a tooltip per chip |
| array of objects | datatable | unchanged |
| empty | italic "Not defined", written 6 times in the template | italic "Not defined", one single block driven by `hasReadOnlyValue` |
| value coming from the schema default | shown as if configured | shown, followed by a discreet **Default** marker (tooltip: "Not set in the configuration: sfdx-hardis applies this default value") |

Two bugs fixed on the way:

- in branch settings, `Global: [object Object]` for an inherited array or object (now printed through the shared formatter);
- **Extension Settings**: a text or number setting left empty showed an empty box; it now shows its default value as the field placeholder.

## What changed

- **New `src/webviews/lwc-ui/modules/s/configValueUtils/configValueUtils.js`** — the shared rules of "how a configuration value is displayed": empty detection, printable form, technical/monospace heuristic, branch-name keys, URL detection, schema default. Used by `pipelineConfig` and `extensionConfig`.
- **`resources/global-theme.css`** — the value kit, so every configuration panel renders a value the same way: `.hardis-field-value` (+ `.mono`), `.hardis-not-set`, `.hardis-field-default`, `.hardis-url-link`. All painted with `--slds-g-color-neutral-base-*` tokens, no hardcoded color, no per-theme duplicate. `.hardis-not-set` and `.hardis-url-link` moved out of `pipelineConfig.css` (they were component-local copies).
- **`pipelineConfig`** — the read-only branch of the field row rebuilt around one `hasReadOnlyValue` flag instead of six `if:true`/`if:false` pairs, each value carrying `valueText` / `valueClass` / `valueTitle` computed in JS (no expression in the template).
- **`extensionConfig`** — default value as the placeholder of the text and number inputs.
- `monitoringConfig`, `documentationConfig` and `anonymizationConfig` needed nothing: they are always-editable (values are inside live inputs) or already render their read-only values as pills.

## Tested

- `yarn lint`, `yarn compile`, `yarn test` — 272 passing, including the new `src/test/suite/configValueDisplay.test.ts`
- `yarn dev` (LWC bundle builds) then `yarn test:ui` — 15 passing
- `npx prettier --check` on every `.ts`/`.js` touched (`global-theme.css` was already prettier-dirty on `main`; CSS is not linted by MegaLinter)
- Visual check with the documentation screenshot harness (real Extension Development Host, light theme) on the Deployment and User Stories tabs: the coverage number, the manual-actions enum chip, the `integration` branch chip and the `Default` marker all render as intended.

New tests (`configValueDisplay.test.ts`) assert, statically on the component sources and by evaluating the shared helpers for real:

- no value in the read-only block uses `slds-text-color_weak` any more
- every value type renders something readable, and every rendered value carries a tooltip
- "Not defined" is rendered once, from a computed flag
- a value is marked `Default` only when no configuration file carries it
- every `{entry.*}` used by the template is a property the component actually computes
- the value classes live only in `global-theme.css` and hold no hardcoded color
- the new i18n keys exist in the 9 locales, and so does every key the panel uses
