### PR TITLE
fix(deps): pin Salesforce CLI to 2.151.6 while latest ships a broken sf plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 
 ## [8.5.1] 2026-09-09
 
-- A configuration file left unreadable by git conflict markers (`config/.sfdx-hardis.yml` after a merge or a promotion cherry-pick, or committed on purpose by `sf hardis:project:promotion:create --on-conflict commit-with-markers`) no longer breaks the DevOps Pipeline, Pipeline Settings and the status bar: the configuration read earlier in the session is used, with a warning in the output channel naming the file to fix
+- A configuration file left unreadable by git conflict markers no longer breaks the DevOps Pipeline, Pipeline Settings and the status bar: the configuration read earlier in the session is used, with a warning in the output channel naming the file to fix
+  - Concerns `config/.sfdx-hardis.yml` left with conflict markers after a merge or a promotion cherry-pick, or committed on purpose by `sf hardis:project:promotion:create --on-conflict commit-with-markers`
   - Only a configuration that was actually read is reused: a project whose configuration is broken from the start still fails as before
 - **DevOps Pipeline on GitLab**: the CI status of a merge request is the one its own page shows, the pipeline of its head commit, instead of the worst of every pipeline that ever ran on it
   - A merge request commonly has two pipelines on the same commit, the detached merge request pipeline that validates it and the branch pipeline of the push that created the branch: a failed branch pipeline drew the merge request red on the diagram while GitLab showed it green

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- **Salesforce CLI 2.151.6 is now the version the extension installs and checks against**: the published `latest` (2.150.6) ships a broken `sf plugins` command, which prevents the extension from listing the installed plugins
+  - The recommended version is a floor, not a fixed target: as soon as npm publishes 2.151.6 or a later version as `latest`, that version is used again and no downgrade is ever proposed
+  - The version is also pinned for a Salesforce CLI installed with the Windows, macOS or Linux installer, which used to be upgraded to whatever `sf update` picked
+- Automatic dependency updates no longer run again and again when an upgrade does not take effect: they are attempted once per session, so a broken Salesforce CLI release cannot put the extension in an endless install loop
+
 ## [8.5.1] 2026-09-09
 
 - A configuration file left unreadable by git conflict markers (`config/.sfdx-hardis.yml` after a merge or a promotion cherry-pick, or committed on purpose by `sf hardis:project:promotion:create --on-conflict commit-with-markers`) no longer breaks the DevOps Pipeline, Pipeline Settings and the status bar: the configuration read earlier in the session is used, with a warning in the output channel naming the file to fix

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,11 @@
 const showBanner = false;
-export const RECOMMENDED_SFDX_CLI_VERSION = null; //"7.111.6";
+// Pinned when the published `latest` @salesforce/cli is broken. 2.150.6 ships a
+// broken `sf plugins` command, which makes the extension unable to detect the
+// installed plugins: pin the version published as `latest-rc` at the time until
+// `latest` catches up. The pin is a FLOOR, not an exact target (see
+// resolveRecommendedSfCliVersion): as soon as npm `latest` is >= this version,
+// npm `latest` wins again and this constant can be reset to null.
+export const RECOMMENDED_SFDX_CLI_VERSION: string | null = "2.151.6";
 export const NODE_JS_MINIMUM_VERSION = 24.0;
 // Pre-release identifiers are ignored when comparing, so 8.0.0-beta.x satisfies it
 export const RECOMMENDED_MINIMAL_SFDX_HARDIS_VERSION: string = "8.4.1";

--- a/src/hardis-plugins-provider.ts
+++ b/src/hardis-plugins-provider.ts
@@ -15,6 +15,7 @@ import {
 import {
   getPluginInstallKindFromText,
   mustUpgradeSfdxHardisPlugin,
+  resolveRecommendedSfCliVersion,
 } from "./utils/pluginsVersionUtils";
 import { Logger } from "./logger";
 import { ThemeUtils } from "./utils/themeUtils";
@@ -31,7 +32,6 @@ import { applyPluginsDetailPassInfo } from "./utils/dependenciesStatus";
 import {
   NODE_JS_MINIMUM_VERSION,
   RECOMMENDED_MINIMAL_SFDX_HARDIS_VERSION,
-  RECOMMENDED_SFDX_CLI_VERSION,
   DOCSITE_URL,
 } from "./constants";
 import {
@@ -56,6 +56,11 @@ let PLUGINS_DETAIL_ITEMS: any[] | null = null;
 // Per-session guards: prevent repeated dialogs across re-renders
 let PLUGINS_OUTDATED_PROMPT_SHOWN = false;
 let PLUGINS_SFDXHARDIS_PROMPT_SHOWN = false;
+// Deliberately NOT reset by refresh(): the auto-upgrade calls refreshPluginsView()
+// when it completes, so resetting it here would re-arm the auto-upgrade on the very
+// refresh it triggers. When the install does not converge (ex: a broken published
+// Salesforce CLI that keeps reporting the previous version), that is an infinite
+// install loop — see https://github.com/hardisgroupcom/sfdx-hardis/issues/2181
 let PLUGINS_AUTO_UPGRADE_STARTED = false;
 // Guard against concurrent background detail passes
 let PLUGINS_DETAIL_IN_FLIGHT = false;
@@ -586,7 +591,7 @@ export class HardisPluginsProvider implements vscode.TreeDataProvider<StatusTree
       const recommendedSfdxCliVersion: string | null =
         vsConfig.get("ignoreSfdxCliRecommendedVersion") === true
           ? latestSfdxCliVersion
-          : RECOMMENDED_SFDX_CLI_VERSION || latestSfdxCliVersion;
+          : resolveRecommendedSfCliVersion(latestSfdxCliVersion);
 
       const sfdxCliItem = {
         id: `sfdx-cli-info`,
@@ -1116,7 +1121,6 @@ export class HardisPluginsProvider implements vscode.TreeDataProvider<StatusTree
       PLUGINS_DETAIL_ITEMS = null;
       PLUGINS_OUTDATED_PROMPT_SHOWN = false;
       PLUGINS_SFDXHARDIS_PROMPT_SHOWN = false;
-      PLUGINS_AUTO_UPGRADE_STARTED = false;
       PLUGINS_DETAIL_IN_FLIGHT = false;
       nodeInstallOk = false;
       gitInstallOk = false;

--- a/src/test/suite/pluginsVersionUtils.test.ts
+++ b/src/test/suite/pluginsVersionUtils.test.ts
@@ -500,7 +500,10 @@ suite("pluginsVersionUtils", () => {
 
 suite("resolveRecommendedSfCliVersion", () => {
   test("uses npm latest when no version is pinned", () => {
-    assert.strictEqual(resolveRecommendedSfCliVersion("2.150.6", null), "2.150.6");
+    assert.strictEqual(
+      resolveRecommendedSfCliVersion("2.150.6", null),
+      "2.150.6",
+    );
   });
 
   test("returns null when nothing is known (cold cache, no pin)", () => {
@@ -508,7 +511,10 @@ suite("resolveRecommendedSfCliVersion", () => {
   });
 
   test("returns the pin when npm latest is unknown", () => {
-    assert.strictEqual(resolveRecommendedSfCliVersion(null, "2.151.6"), "2.151.6");
+    assert.strictEqual(
+      resolveRecommendedSfCliVersion(null, "2.151.6"),
+      "2.151.6",
+    );
   });
 
   test("forces the pin while npm latest is still below it", () => {

--- a/src/test/suite/pluginsVersionUtils.test.ts
+++ b/src/test/suite/pluginsVersionUtils.test.ts
@@ -1,6 +1,7 @@
 import * as assert from "assert";
 import {
   comparePluginVersions,
+  resolveRecommendedSfCliVersion,
   getPluginInstallKindFromInfo,
   getPluginInstallKindFromText,
   mustUpgradeSfdxHardisPlugin,
@@ -494,5 +495,44 @@ suite("pluginsVersionUtils", () => {
       assert.ok(comparePluginVersions("8.0.0-beta.1", "8.0.0") >= 0);
       assert.ok(comparePluginVersions("8.0.0-alpha.2", "8.0.1") < 0);
     });
+  });
+});
+
+suite("resolveRecommendedSfCliVersion", () => {
+  test("uses npm latest when no version is pinned", () => {
+    assert.strictEqual(resolveRecommendedSfCliVersion("2.150.6", null), "2.150.6");
+  });
+
+  test("returns null when nothing is known (cold cache, no pin)", () => {
+    assert.strictEqual(resolveRecommendedSfCliVersion(null, null), null);
+  });
+
+  test("returns the pin when npm latest is unknown", () => {
+    assert.strictEqual(resolveRecommendedSfCliVersion(null, "2.151.6"), "2.151.6");
+  });
+
+  test("forces the pin while npm latest is still below it", () => {
+    assert.strictEqual(
+      resolveRecommendedSfCliVersion("2.150.6", "2.151.6"),
+      "2.151.6",
+    );
+  });
+
+  test("lets npm latest win again once it reaches the pin", () => {
+    assert.strictEqual(
+      resolveRecommendedSfCliVersion("2.151.6", "2.151.6"),
+      "2.151.6",
+    );
+  });
+
+  test("never downgrades: npm latest above the pin wins", () => {
+    assert.strictEqual(
+      resolveRecommendedSfCliVersion("2.152.0", "2.151.6"),
+      "2.152.0",
+    );
+    assert.strictEqual(
+      resolveRecommendedSfCliVersion("3.0.0", "2.151.6"),
+      "3.0.0",
+    );
   });
 });

--- a/src/test/suite/sfCliUpgradeCommand.test.ts
+++ b/src/test/suite/sfCliUpgradeCommand.test.ts
@@ -30,7 +30,10 @@ suite("buildSfCliUpgradeCommand", () => {
   });
 
   test("falls back to the generic commands when no version is known", () => {
-    assert.strictEqual(buildSfCliUpgradeCommand(NATIVE_PATH, null), "sf update");
+    assert.strictEqual(
+      buildSfCliUpgradeCommand(NATIVE_PATH, null),
+      "sf update",
+    );
     assert.strictEqual(
       buildSfCliUpgradeCommand(NPM_PATH, null),
       "npm install @salesforce/cli@latest -g",

--- a/src/test/suite/sfCliUpgradeCommand.test.ts
+++ b/src/test/suite/sfCliUpgradeCommand.test.ts
@@ -1,0 +1,39 @@
+import * as assert from "assert";
+import {
+  buildSfCliUpgradeCommand,
+  isNativeSfCliInstall,
+} from "../../utils/setupUtils";
+
+// A native installer path (Windows MSI) and an npm global path
+const NATIVE_PATH = "C:/Program Files/sf/bin/sf.cmd";
+const NPM_PATH = "C:/Users/me/AppData/Roaming/npm/sf.cmd";
+
+suite("buildSfCliUpgradeCommand", () => {
+  test("detects native vs npm installs", () => {
+    assert.strictEqual(isNativeSfCliInstall(NATIVE_PATH), true);
+    assert.strictEqual(isNativeSfCliInstall(NPM_PATH), false);
+    assert.strictEqual(isNativeSfCliInstall("missing"), false);
+  });
+
+  test("pins the recommended version on npm installs", () => {
+    assert.strictEqual(
+      buildSfCliUpgradeCommand(NPM_PATH, "2.151.6"),
+      "npm install @salesforce/cli@2.151.6 -g",
+    );
+  });
+
+  test("pins the recommended version on native installs too", () => {
+    assert.strictEqual(
+      buildSfCliUpgradeCommand(NATIVE_PATH, "2.151.6"),
+      "sf update --version 2.151.6",
+    );
+  });
+
+  test("falls back to the untargeted commands when no version is known", () => {
+    assert.strictEqual(buildSfCliUpgradeCommand(NATIVE_PATH, null), "sf update");
+    assert.strictEqual(
+      buildSfCliUpgradeCommand(NPM_PATH, null),
+      "npm install @salesforce/cli@latest -g",
+    );
+  });
+});

--- a/src/test/suite/sfCliUpgradeCommand.test.ts
+++ b/src/test/suite/sfCliUpgradeCommand.test.ts
@@ -29,7 +29,7 @@ suite("buildSfCliUpgradeCommand", () => {
     );
   });
 
-  test("falls back to the untargeted commands when no version is known", () => {
+  test("falls back to the generic commands when no version is known", () => {
     assert.strictEqual(buildSfCliUpgradeCommand(NATIVE_PATH, null), "sf update");
     assert.strictEqual(
       buildSfCliUpgradeCommand(NPM_PATH, null),

--- a/src/utils/dependenciesStatus.ts
+++ b/src/utils/dependenciesStatus.ts
@@ -10,11 +10,8 @@ import {
   resolveSfCliPath,
 } from "./setupUtils";
 import { LwcPanelManager } from "../lwc-panel-manager";
-import {
-  NODE_JS_MINIMUM_VERSION,
-  RECOMMENDED_SFDX_CLI_VERSION,
-  DOCSITE_URL,
-} from "../constants";
+import { NODE_JS_MINIMUM_VERSION, DOCSITE_URL } from "../constants";
+import { resolveRecommendedSfCliVersion } from "./pluginsVersionUtils";
 
 /**
  * Lightweight, cache-only aggregate of the environment's core prerequisites
@@ -408,7 +405,7 @@ async function computeSfCliStatus(): Promise<PrerequisiteStatus> {
   // getNpmLatestVersion never spawns a process and never rejects: it reads a
   // stale cached value immediately (or null) and refreshes in the background
   const latest = await getNpmLatestVersion("@salesforce/cli");
-  const recommended = RECOMMENDED_SFDX_CLI_VERSION || latest || null;
+  const recommended = resolveRecommendedSfCliVersion(latest);
   const isOutdated = !!(recommended && version !== recommended);
   return {
     id: "sf",

--- a/src/utils/pluginsVersionUtils.ts
+++ b/src/utils/pluginsVersionUtils.ts
@@ -7,6 +7,7 @@
 //   sfdx-hardis \u001b[2m7.23.0\u001b[22m \u001b[2m(link) C:\git\sfdx-hardis\u001b[22m
 import { stripAnsiCodes } from "./ansiColors";
 export { stripAnsiCodes };
+import { RECOMMENDED_SFDX_CLI_VERSION } from "../constants";
 
 /**
  * - `localdev`: installed with `sf plugins link` (developed locally)
@@ -206,4 +207,29 @@ export function mustUpgradeSfdxHardisPlugin(params: {
     return false;
   }
   return comparePluginVersions(installedVersion, minimalVersion) < 0;
+}
+
+/**
+ * Resolves the Salesforce CLI version the extension must recommend / install.
+ *
+ * {@link RECOMMENDED_SFDX_CLI_VERSION} is a FLOOR, not an exact target: it
+ * exists to escape a broken published `latest` (ex: 2.150.6 ships a broken
+ * `sf plugins` command). As soon as npm `latest` reaches the pinned version or
+ * goes beyond it, npm `latest` wins again, so the pin expires on its own
+ * without requiring an extension release — and users are never downgraded.
+ *
+ * Returns null when nothing is known (no pin and a cold/offline npm cache), in
+ * which case callers must skip the version comparison entirely.
+ */
+export function resolveRecommendedSfCliVersion(
+  latest: string | null | undefined,
+  pinned: string | null | undefined = RECOMMENDED_SFDX_CLI_VERSION,
+): string | null {
+  if (!pinned) {
+    return latest || null;
+  }
+  if (!latest) {
+    return pinned;
+  }
+  return comparePluginVersions(latest, pinned) >= 0 ? latest : pinned;
 }

--- a/src/utils/setupUtils.ts
+++ b/src/utils/setupUtils.ts
@@ -10,14 +10,16 @@ import {
   resolvePluginInstallKind,
   stripAnsi,
 } from "../utils";
-import { mustUpgradeSfdxHardisPlugin } from "./pluginsVersionUtils";
+import {
+  mustUpgradeSfdxHardisPlugin,
+  resolveRecommendedSfCliVersion,
+} from "./pluginsVersionUtils";
 import { findExecutable } from "./executableUtils";
 import { isMergeDriverEnabled } from "./gitMergeDriverUtils";
 import { t } from "../i18n/i18n";
 import {
   NODE_JS_MINIMUM_VERSION,
   RECOMMENDED_MINIMAL_SFDX_HARDIS_VERSION,
-  RECOMMENDED_SFDX_CLI_VERSION,
 } from "../constants";
 import { listPluginsProvidingHardisCommands } from "./sfdx-hardis-config-utils";
 
@@ -51,13 +53,18 @@ export function isNativeSfCliInstall(
  * Builds the shell command that upgrades the Salesforce CLI to {@link recommended}.
  * - Native installer (Windows MSI / macOS pkg / Linux apt/rpm): `sf update`
  * - npm/node/nvm/fnm install: `npm install @salesforce/cli@<recommended> -g`
+ *
+ * When a recommended version is known, it is pinned on BOTH paths: the version
+ * check compares the installed version against it, so letting either path
+ * resolve a different version keeps the CLI flagged as outdated forever (and
+ * makes the auto-update loop, see runPluginsDetailPass).
  */
 export function buildSfCliUpgradeCommand(
   sfdxPath: string | null | undefined,
   recommended?: string | null,
 ): string {
   if (isNativeSfCliInstall(sfdxPath)) {
-    return "sf update";
+    return recommended ? `sf update --version ${recommended}` : "sf update";
   }
   return `npm install @salesforce/cli@${recommended || "latest"} -g`;
 }
@@ -468,7 +475,7 @@ export class SetupHelper {
         sfdxPathResult.status === "fulfilled"
           ? sfdxPathResult.value
           : "missing";
-      const recommended = RECOMMENDED_SFDX_CLI_VERSION || latest || null;
+      const recommended = resolveRecommendedSfCliVersion(latest);
 
       // Handle legacy sfdx-cli detection
       const legacyMatch = out ? /sfdx-cli\/(\S+)/.exec(out) : null;
@@ -801,9 +808,9 @@ export class SetupHelper {
     // when no version is provided) can install a version that differs from the
     // one the dependency check compares against, keeping the CLI flagged as
     // outdated; pin the resolved npm latest version instead.
-    const recommended =
-      RECOMMENDED_SFDX_CLI_VERSION ||
-      (await getNpmLatestVersion("@salesforce/cli").catch(() => null));
+    const recommended = resolveRecommendedSfCliVersion(
+      await getNpmLatestVersion("@salesforce/cli").catch(() => null),
+    );
     // A legacy sfdx-cli install cannot be upgraded in place: it must be
     // uninstalled before installing @salesforce/cli, otherwise both global
     // binaries coexist and `sf` keeps resolving to the deprecated one


### PR DESCRIPTION
## Problem

The published `@salesforce/cli` `latest` (**2.150.6**) ships a **broken `sf plugins` command**, so the extension cannot list the installed plugins and keeps proposing upgrades that never take effect.

That surfaces as the loop reported in hardisgroupcom/sfdx-hardis#2181, which has a second, structural cause in this repo: the auto-upgrade completion handler calls `refreshPluginsView()` with no argument, and the resulting hard refresh reset `PLUGINS_AUTO_UPGRADE_STARTED` — re-arming the auto-upgrade on the very refresh it triggered. Any upgrade that does not converge loops forever, whatever the reason.

## Changes

**Pin the Salesforce CLI to 2.151.6** (today's `latest-rc`) — `src/constants.ts`.

**The pin is a floor, not an exact target.** New pure helper `resolveRecommendedSfCliVersion(latest, pinned)` in `src/utils/pluginsVersionUtils.ts`: while npm `latest` is below the pin, the pin is forced; the moment npm publishes 2.151.6 or higher as `latest`, `latest` wins again. The pin therefore expires on its own with no extension release, and no user is ever downgraded. The four sites that used `RECOMMENDED_SFDX_CLI_VERSION || latest` now go through it:

- `src/utils/dependenciesStatus.ts` (Welcome page prerequisites)
- `src/utils/setupUtils.ts` (Setup panel check, `installSfCliWithNpm`)
- `src/hardis-plugins-provider.ts` (dependencies tree + auto-upgrade)

**Native installs honor the version too.** `buildSfCliUpgradeCommand()` was dropping `recommended` and running a bare `sf update` for Windows MSI / macOS pkg / apt / rpm installs, so those users would stay on the broken release *and* be flagged outdated forever. It now builds `sf update --version <v>` (verified against `sf update --help`).

**Fix the install loop.** `PLUGINS_AUTO_UPGRADE_STARTED` is no longer reset by `refresh()`, so auto-update is genuinely attempted once per session, as its comment already claimed.

## Tests

- 6 cases for the floor logic in `src/test/suite/pluginsVersionUtils.test.ts` (no pin, cold cache, pin forced, pin reached, pin exceeded)
- New `src/test/suite/sfCliUpgradeCommand.test.ts` covering both install kinds, with and without a known version

`yarn lint`, `yarn compile` and `yarn test` all pass.

## Unpinning later

Optional cleanup only: set `RECOMMENDED_SFDX_CLI_VERSION` back to `null` once 2.151.6+ is published as `latest`. The floor already yields to `latest` on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
