### PR TITLE
fix(pipeline): full width list setting tables, and promotion branches named after the UTC minute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Pipeline Settings: a table of a list setting (`allowedPromotionSteps`, `monitoringCommands`, installed packages...) now takes the whole width of the panel instead of shrinking to its content, which printed branch names one character per line
+- DevOps Pipeline: promotion branches named `promotion/<source>/<target>/<YYYY-MM-DD>-<HHMM>` by sfdx-hardis (with `-2`, `-3`... when the name was taken) are recognized, next to the `<YYYY-MM-DD>-<counter>` names of earlier promotions
 
 ## [8.5.2] 2026-09-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Pipeline Settings: a table of a list setting (`allowedPromotionSteps`, `monitoringCommands`, installed packages...) now takes the whole width of the panel instead of shrinking to its content, which printed branch names one character per line
+
 ## [8.5.2] 2026-09-10
 
 - **Salesforce CLI 2.151.6 is now the version the extension installs and checks against**: the published `latest` (2.150.6) ships a broken `sf plugins` command, which prevents the extension from listing the installed plugins

--- a/resources/global-theme.css
+++ b/resources/global-theme.css
@@ -1422,9 +1422,16 @@ lightning-helptext::part(icon) {
   max-width: 100%;
   justify-content: flex-start;
 }
+/* s-hardis-datatable belongs in that list too, and not only to look right:
+   lightning-datatable sizes its columns in JS from the width of its own host
+   element, and a flex item left at "flex: 0 1 auto" is only as wide as its
+   content. The table of a list setting came back 220px wide, its columns at
+   their minimum, printing a branch name one character per line
+   (allowedPromotionSteps: source + target). */
 .hardis-field-row.stacked .hardis-field-control > lightning-input,
 .hardis-field-row.stacked .hardis-field-control > lightning-textarea,
-.hardis-field-row.stacked .hardis-field-control > lightning-dual-listbox {
+.hardis-field-row.stacked .hardis-field-control > lightning-dual-listbox,
+.hardis-field-row.stacked .hardis-field-control > s-hardis-datatable {
   flex: 1 1 100%;
   min-width: 0;
 }

--- a/src/test/suite/promotionBranchUtils.test.ts
+++ b/src/test/suite/promotionBranchUtils.test.ts
@@ -366,11 +366,38 @@ suite("promotionBranchUtils", () => {
     );
   });
 
-  test("parses promotion/<source>/<target>/<YYYY-MM-DD>-<counter> and nothing else", () => {
+  test("parses promotion/<source>/<target>/<YYYY-MM-DD>-<HHMM>, the <YYYY-MM-DD>-<counter> names of the first releases, and nothing else", () => {
+    assert.deepStrictEqual(
+      parsePromotionBranchName("promotion/uat/preprod/2026-09-06-1430"),
+      {
+        sourceBranch: "uat",
+        targetBranch: "preprod",
+        date: "2026-09-06",
+        time: "1430",
+        counter: 1,
+      },
+    );
+    assert.deepStrictEqual(
+      parsePromotionBranchName("promotion/uat/preprod/2026-09-06-0005-2"),
+      {
+        sourceBranch: "uat",
+        targetBranch: "preprod",
+        date: "2026-09-06",
+        time: "0005",
+        counter: 2,
+      },
+    );
+    // A counter only follows a real time of day
+    assert.strictEqual(
+      isPromotionBranchName("promotion/uat/preprod/2026-09-06-2460-2"),
+      false,
+    );
+    // Promotions of the first releases can still be open or waiting in a branch
     assert.deepStrictEqual(parsePromotionBranchName(PROMOTION_BRANCH), {
       sourceBranch: "uat",
       targetBranch: "preprod",
       date: "2026-09-06",
+      time: null,
       counter: 1,
     });
     assert.strictEqual(

--- a/src/utils/pipeline/promotionBranchUtils.ts
+++ b/src/utils/pipeline/promotionBranchUtils.ts
@@ -41,6 +41,12 @@ export interface PromotionBranchNameParts {
   sourceBranch: string;
   targetBranch: string;
   date: string;
+  /**
+   * UTC hour and minutes the promotion was assembled at (HHMM). Null for a name of the
+   * first releases of the feature, which carried a counter after the date instead.
+   */
+  time: string | null;
+  /** 1 unless the name ends with -2, -3... because the same name was already taken */
   counter: number;
 }
 
@@ -154,10 +160,18 @@ export function allowedPromotionTargetBranches(
   );
 }
 
+// HHMM of a valid time of day: 0000 to 2359
+const PROMOTION_BRANCH_TIME_REGEX = /^([01]\d|2[0-3])[0-5]\d$/;
+
 /**
  * Splits a promotion branch name into its parts. The convention is not configurable:
- * promotion/<source major branch>/<target major branch>/<YYYY-MM-DD>-<counter>.
+ * promotion/<source major branch>/<target major branch>/<YYYY-MM-DD>-<HHMM> (UTC), with
+ * -2, -3... added by sfdx-hardis only when that name is already taken.
  * Returns null for anything else, including a bare "promotion/xxx".
+ *
+ * Same rules as parsePromotionBranchName in sfdx-hardis: the <YYYY-MM-DD>-<counter> names
+ * of the first releases are still recognized, since those promotions can still be open or
+ * waiting in a branch, and a group of four digits that is a valid time of day is the time.
  */
 export function parsePromotionBranchName(
   branchName: string | undefined | null,
@@ -170,21 +184,39 @@ export function parsePromotionBranchName(
     return null;
   }
   const [, sourceBranch, targetBranch, suffix] = segments;
-  const suffixMatch = suffix.match(/^(\d{4}-\d{2}-\d{2})-(\d+)$/);
+  const suffixMatch = suffix.match(/^(\d{4}-\d{2}-\d{2})-(\d+)(?:-(\d+))?$/);
   if (!sourceBranch || !targetBranch || !suffixMatch) {
     return null;
+  }
+  const [, date, first, second] = suffixMatch;
+  if (second !== undefined) {
+    // <HHMM>-<n>: the part before the counter must really be a time
+    return PROMOTION_BRANCH_TIME_REGEX.test(first)
+      ? {
+          sourceBranch,
+          targetBranch,
+          date,
+          time: first,
+          counter: parseInt(second, 10),
+        }
+      : null;
+  }
+  if (PROMOTION_BRANCH_TIME_REGEX.test(first)) {
+    return { sourceBranch, targetBranch, date, time: first, counter: 1 };
   }
   return {
     sourceBranch,
     targetBranch,
-    date: suffixMatch[1],
-    counter: parseInt(suffixMatch[2], 10),
+    date,
+    time: null,
+    counter: parseInt(first, 10),
   };
 }
 
 /**
- * True for a branch following the promotion/<source>/<target>/<YYYY-MM-DD>-<counter>
- * convention: a hand-named promotion/xxx branch is not a promotion branch.
+ * True for a branch following the promotion/<source>/<target>/<YYYY-MM-DD>-<HHMM>
+ * convention (or the <YYYY-MM-DD>-<counter> one of the first releases): a hand-named
+ * promotion/xxx branch is not a promotion branch.
  */
 export function isPromotionBranchName(
   branchName: string | undefined | null,

--- a/src/webviews/lwc-ui/modules/s/pipeline/pipeline.js
+++ b/src/webviews/lwc-ui/modules/s/pipeline/pipeline.js
@@ -2514,7 +2514,9 @@ export default class Pipeline extends SharedMixin(LightningElement) {
     if (pr.isPromotion === true) {
       return true;
     }
-    return /^promotion\/[^/]+\/[^/]+\/\d{4}-\d{2}-\d{2}-\d+$/.test(source);
+    // <YYYY-MM-DD>-<HHMM>, with -<n> when the name was taken, and the <YYYY-MM-DD>-<counter>
+    // names of the first releases (parsePromotionBranchName checks the time, a fallback does not)
+    return /^promotion\/[^/]+\/[^/]+\/\d{4}-\d{2}-\d{2}-\d+(?:-\d+)?$/.test(source);
   }
 
   // The toggle only shows when the current view holds something to reveal

--- a/src/webviews/lwc-ui/modules/s/pipeline/pipeline.js
+++ b/src/webviews/lwc-ui/modules/s/pipeline/pipeline.js
@@ -2516,7 +2516,9 @@ export default class Pipeline extends SharedMixin(LightningElement) {
     }
     // <YYYY-MM-DD>-<HHMM>, with -<n> when the name was taken, and the <YYYY-MM-DD>-<counter>
     // names of the first releases (parsePromotionBranchName checks the time, a fallback does not)
-    return /^promotion\/[^/]+\/[^/]+\/\d{4}-\d{2}-\d{2}-\d+(?:-\d+)?$/.test(source);
+    return /^promotion\/[^/]+\/[^/]+\/\d{4}-\d{2}-\d{2}-\d+(?:-\d+)?$/.test(
+      source,
+    );
   }
 
   // The toggle only shows when the current view holds something to reveal


### PR DESCRIPTION
Feedback from the promotion branches pilot: [discussion 2120](https://github.com/orgs/hardisgroupcom/discussions/2120#discussioncomment-18392308).

## Pipeline Settings: the table of a list setting takes the full width

> In the DevOps Pipeline Settings UI, when specifying the source and target branches for promotion, the width of the table is quite small. So names of branches are squished vertically.

The datatable of a list setting sits in `.hardis-field-control`, which is a flex container, and nothing told it to grow. As a flex item at `flex: 0 1 auto` it is only as wide as its content, and `lightning-datatable` sizes its columns in JS from the width of its own host element (`autoWidthStrategy` reads `scrollerX.offsetWidth`): the two columns of `allowedPromotionSteps` came back at their minimum, and `uat` / `preprod` were printed one character per line.

`s-hardis-datatable` joins the elements that already take the full width of a stacked field row (`lightning-input`, `lightning-textarea`, `lightning-dual-listbox`).

Measured in Chrome on the real `global-theme.css`, with the Pipeline Settings markup and the DOM `lightning-datatable` renders: the width the column strategy reads goes from **220px to 995px** in a 1000px panel. `flex-basis: 100%` alone is enough, no `width` declaration needed.

Every list setting of the panel benefits (`allowedPromotionSteps`, `monitoringCommands`, the installed packages, the metadata retriever presets...). The deployment actions tables were escaping the problem only because their columns declare an `initialWidth`.

## DevOps Pipeline: promotion branches named after the UTC minute

sfdx-hardis now names promotion branches `promotion/<source>/<target>/<YYYY-MM-DD>-<HHMM>`, with `-2`, `-3`... only when that name is already taken ([sfdx-hardis#2189](https://github.com/hardisgroupcom/sfdx-hardis/pull/2189)).

- `parsePromotionBranchName` accepts that name, with or without its counter, so `isPromotionOfStep` still draws the open promotion on the edge between its two branches and its Pull Request is still a vehicle.
- The fallback regex of `pipeline.js` (used when a Pull Request is not flagged `isPromotion`) accepts the optional counter too.
- The `<YYYY-MM-DD>-<counter>` names of the first releases stay recognized: a promotion assembled before sfdx-hardis is upgraded can still be open. Same rule as the CLI: a group of four digits that is a valid time of day is the time, and a counter only follows a real time.

Compile and lint clean. The parser was checked directly on the compiled module (new name, new name with counter, legacy names, and the rejected shapes); `promotionBranchUtils.test.ts` covers the same cases in the extension test run.
